### PR TITLE
Change default baudrate from 115200 to 1000000

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
         },
         "baochip.monitor.defaultBaud": {
           "type": "number",
-          "default": 115200,
+          "default": 1000000,
           "minimum": 1,
           "description": "Default baud rate for the serial monitor."
         },

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -10,7 +10,7 @@ async function updateSetting(key: string, value: any, target?: vscode.Configurat
 }
 
 export const getPythonCmd = () => cfg().get<string>('baochip.pythonCommand') || '';
-export const getDefaultBaud = () => cfg().get<number>('baochip.monitor.defaultBaud') || 115200;
+export const getDefaultBaud = () => cfg().get<number>('baochip.monitor.defaultBaud') || 1000000;
 
 export const getMonitorDefaultPort = (): "run" | "bootloader" => (cfg().get<string>('baochip.monitorDefaultPort') as any) || 'run';
 export const setMonitorDefaultPort = (v: "run" | "bootloader") => updateSetting('baochip.monitorDefaultPort', v);


### PR DESCRIPTION
This is in case a user is using a classical UART adapter to connect to the board - in those cases, the setting actually matters and the default rate for all baochip ports is 1,000,000