### PR TITLE
out of tree workspace support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 - **Build • Flash • Boot** - builds, flashes, and restarts the board without opening a monitor
 - Warning when a built or flashed .uf2 is too big for its dabao flash region (oversized images are silently truncated and leave the board running no app)
 - Warning when rustc is not a stable build; nightly, beta, and dev toolchains are unsupported and now say so up front rather than failing in the toolchain download
+- Out-of-tree projects can be a cargo workspace: pick which crates to build and they are built together into one apps.uf2. A project with a single crate needs no picking
 
 ### Changed
 - **Build • Flash • Monitor** is now called **Build • Flash • Boot • Monitor** - it always booted the board after flashing
+- The app picker now selects several apps at once, starting from what is already set; previously it replaced the whole setting with one app
+- The app setting shows a warning when it names something the project does not have, rather than silently building without it
 
 ### Fixed
 - Boot after flashing sometimes did nothing while the log claimed success; it is now confirmed and resent if the board is still in the bootloader

--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -294,5 +294,6 @@
 	"These workspace members have no readable Cargo.toml: {0}": "Diese Workspace-Mitglieder haben keine lesbare Cargo.toml: {0}",
 	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "Workspace-Mitglieder mit \"*\" werden nicht unterstuetzt: {0}. Bitte jeden Crate-Ordner einzeln auflisten.",
 	"Click to select the crate to build": "Klicken, um die zu bauende Crate auszuwaehlen",
-	"Invalid crate name: {0}": "Ungueltiger Crate-Name: {0}"
+	"Invalid crate name: {0}": "Ungueltiger Crate-Name: {0}",
+	"Not found in this project: {0}": "In diesem Projekt nicht gefunden: {0}"
 }

--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -289,5 +289,10 @@
 	"CI kernel sync is only available for the dabao target. Use manual kernel mode for \"{0}\".": "Die CI-Kernel-Synchronisierung ist nur für das dabao-Ziel verfügbar. Verwenden Sie für \"{0}\" den manuellen Kernel-Modus.",
 	"App directory already exists: {0}": "Das App-Verzeichnis existiert bereits: {0}",
 	"Ignoring invalid extra cargo features: {0}": "Ungültige zusätzliche Cargo-Features werden ignoriert: {0}",
-	"Baochip: {0} is {1} over the {2} limit for dabao. It will not run on the device.": "Baochip: {0} liegt {1} über dem dabao-Limit von {2}. Die Datei wird auf dem Gerät nicht ausgeführt."
+	"Baochip: {0} is {1} over the {2} limit for dabao. It will not run on the device.": "Baochip: {0} liegt {1} über dem dabao-Limit von {2}. Die Datei wird auf dem Gerät nicht ausgeführt.",
+	"No crates found in {0}.": "Keine Crates in {0} gefunden.",
+	"Select crate": "Crate auswaehlen",
+	"These workspace members have no readable Cargo.toml: {0}": "Diese Workspace-Mitglieder haben keine lesbare Cargo.toml: {0}",
+	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "Workspace-Mitglieder mit \"*\" werden nicht unterstuetzt: {0}. Bitte jeden Crate-Ordner einzeln auflisten.",
+	"Click to select the crate to build": "Klicken, um die zu bauende Crate auszuwaehlen"
 }

--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -168,7 +168,6 @@
 	"Failed to update xous-core rev in Cargo.toml: {0}": "xous-core-Rev in Cargo.toml konnte nicht aktualisiert werden: {0}",
 	"apps.uf2 not found in {0}. Run a build first.": "apps.uf2 nicht gefunden in {0}. Bitte zuerst einen Build durchführen.",
 	"Baochip: Converting ELF to UF2...": "Baochip: ELF wird in UF2 konvertiert...",
-	"Could not read package name from Cargo.toml.": "Paketname konnte nicht aus Cargo.toml gelesen werden.",
 	"ELF not found at {0}. Has the build completed successfully?": "ELF-Datei nicht gefunden unter {0}. Wurde der Build erfolgreich abgeschlossen?",
 	"Baochip: ELF to UF2 conversion failed. See output for details.": "Baochip: ELF-zu-UF2-Konvertierung fehlgeschlagen. Details im Ausgabefenster.",
 	"Baochip: xous-tools installed successfully.": "Baochip: xous-tools erfolgreich installiert.",
@@ -294,5 +293,6 @@
 	"Select crate": "Crate auswaehlen",
 	"These workspace members have no readable Cargo.toml: {0}": "Diese Workspace-Mitglieder haben keine lesbare Cargo.toml: {0}",
 	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "Workspace-Mitglieder mit \"*\" werden nicht unterstuetzt: {0}. Bitte jeden Crate-Ordner einzeln auflisten.",
-	"Click to select the crate to build": "Klicken, um die zu bauende Crate auszuwaehlen"
+	"Click to select the crate to build": "Klicken, um die zu bauende Crate auszuwaehlen",
+	"Invalid crate name: {0}": "Ungueltiger Crate-Name: {0}"
 }

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -168,7 +168,6 @@
 	"Failed to update xous-core rev in Cargo.toml: {0}": "Cargo.toml の xous-core リビジョンの更新に失敗しました: {0}",
 	"apps.uf2 not found in {0}. Run a build first.": "{0} に apps.uf2 が見つかりません。先にビルドを実行してください。",
 	"Baochip: Converting ELF to UF2...": "Baochip: ELF を UF2 に変換中...",
-	"Could not read package name from Cargo.toml.": "Cargo.toml からパッケージ名を読み取れませんでした。",
 	"ELF not found at {0}. Has the build completed successfully?": "{0} に ELF ファイルが見つかりません。ビルドは正常に完了しましたか？",
 	"Baochip: ELF to UF2 conversion failed. See output for details.": "Baochip: ELF から UF2 への変換に失敗しました。詳細は出力を確認してください。",
 	"Baochip: xous-tools installed successfully.": "Baochip: xous-tools のインストールが完了しました。",
@@ -294,5 +293,6 @@
 	"Select crate": "クレートを選択",
 	"These workspace members have no readable Cargo.toml: {0}": "次のワークスペースメンバーには読み取り可能な Cargo.toml がありません: {0}",
 	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "\"*\" を使うワークスペースメンバーはサポートされていません: {0}。各クレートのフォルダーを個別に指定してください。",
-	"Click to select the crate to build": "ビルドするクレートを選択するにはクリックしてください"
+	"Click to select the crate to build": "ビルドするクレートを選択するにはクリックしてください",
+	"Invalid crate name: {0}": "無効なクレート名: {0}"
 }

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -289,5 +289,10 @@
 	"CI kernel sync is only available for the dabao target. Use manual kernel mode for \"{0}\".": "CI カーネル同期は dabao ターゲットでのみ利用できます。\"{0}\" には手動カーネルモードを使用してください。",
 	"App directory already exists: {0}": "アプリディレクトリは既に存在します: {0}",
 	"Ignoring invalid extra cargo features: {0}": "無効な追加 cargo フィーチャーを無視します: {0}",
-	"Baochip: {0} is {1} over the {2} limit for dabao. It will not run on the device.": "Baochip: {0} は dabao の上限 {2} を {1} 超えています。デバイス上では実行されません。"
+	"Baochip: {0} is {1} over the {2} limit for dabao. It will not run on the device.": "Baochip: {0} は dabao の上限 {2} を {1} 超えています。デバイス上では実行されません。",
+	"No crates found in {0}.": "{0} にクレートが見つかりません。",
+	"Select crate": "クレートを選択",
+	"These workspace members have no readable Cargo.toml: {0}": "次のワークスペースメンバーには読み取り可能な Cargo.toml がありません: {0}",
+	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "\"*\" を使うワークスペースメンバーはサポートされていません: {0}。各クレートのフォルダーを個別に指定してください。",
+	"Click to select the crate to build": "ビルドするクレートを選択するにはクリックしてください"
 }

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -294,5 +294,6 @@
 	"These workspace members have no readable Cargo.toml: {0}": "次のワークスペースメンバーには読み取り可能な Cargo.toml がありません: {0}",
 	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "\"*\" を使うワークスペースメンバーはサポートされていません: {0}。各クレートのフォルダーを個別に指定してください。",
 	"Click to select the crate to build": "ビルドするクレートを選択するにはクリックしてください",
-	"Invalid crate name: {0}": "無効なクレート名: {0}"
+	"Invalid crate name: {0}": "無効なクレート名: {0}",
+	"Not found in this project: {0}": "このプロジェクトに見つかりません: {0}"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -294,5 +294,6 @@
 	"These workspace members have no readable Cargo.toml: {0}": "以下工作区成员没有可读取的 Cargo.toml: {0}",
 	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "不支持使用 \"*\" 的工作区成员: {0}。请逐个列出每个 crate 文件夹。",
 	"Click to select the crate to build": "点击选择要构建的 crate",
-	"Invalid crate name: {0}": "无效的 crate 名称: {0}"
+	"Invalid crate name: {0}": "无效的 crate 名称: {0}",
+	"Not found in this project: {0}": "在此项目中找不到: {0}"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -289,5 +289,10 @@
 	"CI kernel sync is only available for the dabao target. Use manual kernel mode for \"{0}\".": "CI 内核同步仅适用于 dabao 目标。对“{0}”请使用手动内核模式。",
 	"App directory already exists: {0}": "应用目录已存在: {0}",
 	"Ignoring invalid extra cargo features: {0}": "已忽略无效的额外 cargo 特性：{0}",
-	"Baochip: {0} is {1} over the {2} limit for dabao. It will not run on the device.": "Baochip：{0} 比 dabao 的 {2} 上限大 {1}，无法在设备上运行。"
+	"Baochip: {0} is {1} over the {2} limit for dabao. It will not run on the device.": "Baochip：{0} 比 dabao 的 {2} 上限大 {1}，无法在设备上运行。",
+	"No crates found in {0}.": "在 {0} 中未找到 crate。",
+	"Select crate": "选择 crate",
+	"These workspace members have no readable Cargo.toml: {0}": "以下工作区成员没有可读取的 Cargo.toml: {0}",
+	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "不支持使用 \"*\" 的工作区成员: {0}。请逐个列出每个 crate 文件夹。",
+	"Click to select the crate to build": "点击选择要构建的 crate"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -168,7 +168,6 @@
 	"Failed to update xous-core rev in Cargo.toml: {0}": "更新 Cargo.toml 中的 xous-core rev 失败：{0}",
 	"apps.uf2 not found in {0}. Run a build first.": "{0} 中未找到 apps.uf2。请先运行构建。",
 	"Baochip: Converting ELF to UF2...": "Baochip：正在将 ELF 转换为 UF2...",
-	"Could not read package name from Cargo.toml.": "无法从 Cargo.toml 读取包名。",
 	"ELF not found at {0}. Has the build completed successfully?": "{0} 处未找到 ELF 文件。构建是否已成功完成？",
 	"Baochip: ELF to UF2 conversion failed. See output for details.": "Baochip：ELF 转换为 UF2 失败。详情请查看输出。",
 	"Baochip: xous-tools installed successfully.": "Baochip：xous-tools 安装成功。",
@@ -294,5 +293,6 @@
 	"Select crate": "选择 crate",
 	"These workspace members have no readable Cargo.toml: {0}": "以下工作区成员没有可读取的 Cargo.toml: {0}",
 	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "不支持使用 \"*\" 的工作区成员: {0}。请逐个列出每个 crate 文件夹。",
-	"Click to select the crate to build": "点击选择要构建的 crate"
+	"Click to select the crate to build": "点击选择要构建的 crate",
+	"Invalid crate name: {0}": "无效的 crate 名称: {0}"
 }

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -294,5 +294,6 @@
 	"These workspace members have no readable Cargo.toml: {0}": "下列工作區成員沒有可讀取的 Cargo.toml: {0}",
 	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "不支援使用 \"*\" 的工作區成員: {0}。請逐一列出每個 crate 資料夾。",
 	"Click to select the crate to build": "按一下以選擇要建置的 crate",
-	"Invalid crate name: {0}": "無效的 crate 名稱: {0}"
+	"Invalid crate name: {0}": "無效的 crate 名稱: {0}",
+	"Not found in this project: {0}": "在此專案中找不到: {0}"
 }

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -289,5 +289,10 @@
 	"CI kernel sync is only available for the dabao target. Use manual kernel mode for \"{0}\".": "CI 核心同步僅適用於 dabao 目標。對「{0}」請使用手動核心模式。",
 	"App directory already exists: {0}": "應用程式目錄已存在: {0}",
 	"Ignoring invalid extra cargo features: {0}": "已忽略無效的額外 cargo 特性：{0}",
-	"Baochip: {0} is {1} over the {2} limit for dabao. It will not run on the device.": "Baochip：{0} 比 dabao 的 {2} 上限大 {1}，無法在裝置上執行。"
+	"Baochip: {0} is {1} over the {2} limit for dabao. It will not run on the device.": "Baochip：{0} 比 dabao 的 {2} 上限大 {1}，無法在裝置上執行。",
+	"No crates found in {0}.": "在 {0} 中找不到 crate。",
+	"Select crate": "選擇 crate",
+	"These workspace members have no readable Cargo.toml: {0}": "下列工作區成員沒有可讀取的 Cargo.toml: {0}",
+	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "不支援使用 \"*\" 的工作區成員: {0}。請逐一列出每個 crate 資料夾。",
+	"Click to select the crate to build": "按一下以選擇要建置的 crate"
 }

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -168,7 +168,6 @@
 	"Failed to update xous-core rev in Cargo.toml: {0}": "更新 Cargo.toml 中的 xous-core rev 失敗：{0}",
 	"apps.uf2 not found in {0}. Run a build first.": "{0} 中找不到 apps.uf2。請先執行建置。",
 	"Baochip: Converting ELF to UF2...": "Baochip：正在將 ELF 轉換為 UF2...",
-	"Could not read package name from Cargo.toml.": "無法從 Cargo.toml 讀取套件名稱。",
 	"ELF not found at {0}. Has the build completed successfully?": "{0} 處找不到 ELF 檔案。建置是否已成功完成？",
 	"Baochip: ELF to UF2 conversion failed. See output for details.": "Baochip：ELF 轉換為 UF2 失敗。詳情請查看輸出。",
 	"Baochip: xous-tools installed successfully.": "Baochip：xous-tools 安裝成功。",
@@ -294,5 +293,6 @@
 	"Select crate": "選擇 crate",
 	"These workspace members have no readable Cargo.toml: {0}": "下列工作區成員沒有可讀取的 Cargo.toml: {0}",
 	"Workspace members using \"*\" are not supported: {0}. List each crate folder individually.": "不支援使用 \"*\" 的工作區成員: {0}。請逐一列出每個 crate 資料夾。",
-	"Click to select the crate to build": "按一下以選擇要建置的 crate"
+	"Click to select the crate to build": "按一下以選擇要建置的 crate",
+	"Invalid crate name: {0}": "無效的 crate 名稱: {0}"
 }

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -1,7 +1,6 @@
 {
 	"ext.displayName": "Baochip",
 	"ext.description": "In VS Code Anwendungen für Baochip-Mikrocontroller entwickeln, flashen und debuggen.",
-
 	"cmd.openWelcome": "Willkommen öffnen",
 	"cmd.openSettings": "Einstellungen öffnen",
 	"cmd.setBootPort": "Seriellport für Bootloader-Modus festlegen",
@@ -23,37 +22,30 @@
 	"cmd.resetUvSetup": "UV-Konfiguration zurücksetzen",
 	"cmd.rerunSetup": "Erweiterungs-Setup erneut ausführen",
 	"cmd.collectDiagnostics": "Diagnose sammeln",
-
 	"cfg.title.general": "Baochip - Allgemein",
 	"cfg.general.showWelcomeOnStartup": "Beim Aktivieren der Erweiterung automatisch die Willkommensseite öffnen.",
 	"cfg.general.rerunSetup": "Installiert uv und die von Baochip verwendete Python-Umgebung neu. Dies wird bei der ersten Verwendung von Baochip automatisch ausgeführt; verwenden Sie es, um die Einrichtung erneut auszuführen, falls sie fehlgeschlagen ist oder Sie sie neu aufbauen möchten. [Erweiterungs-Setup erneut ausführen](command:baochip.rerunSetup)",
-
 	"cfg.title.ports": "Baochip - Ports",
 	"cfg.ports.bootloader": "Seriellport, der im Bootloader-/UF2-Laufwerksmodus erscheint.",
 	"cfg.ports.run": "Seriellport für den Run-Modus (normale Firmware-Logs).",
 	"cfg.ports.monitorDefault": "Welchen Port die Monitor-Schaltfläche standardmäßig nutzt.",
-
 	"cfg.title.monitor": "Baochip - Monitor",
 	"cfg.monitor.defaultBaud": "Standard-Baudrate für den seriellen Monitor.",
 	"cfg.monitor.crlf": "In der Zeilenübertragung CRLF als Zeilenende verwenden.",
 	"cfg.monitor.raw": "Tastendrücke sofort senden (Raw-Modus).",
 	"cfg.monitor.echo": "Lokales Echo der Eingabe.",
-
 	"cfg.title.build": "Baochip - Build",
 	"cfg.build.buildMode": "Build-Modus. 'auto' erkennt automatisch (xous-core-Modus wenn apps-dabao/ vorhanden, sonst out-of-tree). Überschreiben, um einen bestimmten Modus zu erzwingen.",
 	"cfg.build.target": "Aktuell ausgewähltes Build-Ziel (z. B. dabao, baosec). Wird sowohl für In-tree- als auch für Out-of-Tree-Builds zur Auswahl des Zielboards verwendet.",
-
 	"cfg.title.intree": "Baochip - In-tree-Builds (xous-core)",
 	"cfg.intree.xousCorePath": "Pfad zu Ihrem lokalen xous-core-Checkout (Ordner). Nur für In-tree-Builds erforderlich (wenn Apps innerhalb des xous-core-Repositorys gebaut werden).",
-	"cfg.intree.appName": "Name der Baochip-App unter xous-core/apps-dabao/. Mehrere Apps können durch Leerzeichen getrennt werden (z. B. 'helloworld demo_app'). Leer lassen, um nur das Ziel zu bauen. Nur für In-tree-Builds.",
-
+	"cfg.intree.appName": "Zu bauende Crates, durch Leerzeichen getrennt (z. B. 'helloworld demo_app'). Apps in einem xous-core-Checkout, Workspace-Crates out-of-tree. In xous-core leer lassen fuer nur das Basis-Systemabbild.",
 	"cfg.title.flashing": "Baochip - Flashen",
 	"cfg.title.outOfTree": "Baochip - Out-of-Tree-Builds",
 	"cfg.outOfTree.kernelMode": "Wie die Erweiterung loader.uf2 und xous.uf2 für Out-of-Tree-Flashing bezieht. Nur für Out-of-Tree-Builds. 'ask' zeigt beim ersten Mal einen Einrichtungsdialog. 'ci-sync' holt den neuesten xous-core-Commit von GitHub, aktualisiert Cargo.toml und lädt passende Kernel-Dateien von CI. 'manual' verwendet Dateien aus dem in baochip.outOfTree.kernelFilesPath angegebenen Ordner.",
 	"cfg.outOfTree.kernelFilesPath": "Ordner mit loader.uf2 und xous.uf2 für manuelles Out-of-Tree-Flashing. Wird nur verwendet, wenn baochip.outOfTree.kernelMode auf 'manual' gesetzt ist.",
 	"cfg.outOfTree.extraFeatures": "Zusätzliche Cargo-Feature-Flags für Out-of-Tree-Builds, über das Standard-Set board-dabao/bao1x hinaus (z. B. [\"usb\", \"my-feature\"]). Nur für Out-of-Tree-Builds.",
 	"cfg.flashing.location": "Speicherort des eingehängten Baochip-UF2-Laufwerks (D:\\ oder ein anderes Laufwerksbuchstaben-Laufwerk unter Windows, /Volumes/BAOCHIP unter macOS, /media/$(whoami)/BAOCHIP unter Linux).",
-
 	"views.container.title": "Baochip",
 	"views.main": "Baochip",
 	"views.docs": "Dokumentation",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -1,7 +1,6 @@
 {
 	"ext.displayName": "Baochip",
 	"ext.description": "VS Code で Baochip マイコン向けアプリを開発・フラッシュ・デバッグできます。",
-
 	"cmd.openWelcome": "ようこそを開く",
 	"cmd.openSettings": "設定を開く",
 	"cmd.setBootPort": "ブートローダーモードのシリアルポートを設定",
@@ -23,37 +22,30 @@
 	"cmd.resetUvSetup": "UV 設定をリセット",
 	"cmd.rerunSetup": "拡張機能のセットアップを再実行",
 	"cmd.collectDiagnostics": "診断情報を収集",
-
 	"cfg.title.general": "Baochip - 全般",
 	"cfg.general.showWelcomeOnStartup": "拡張機能の起動時に「ようこそ」ページを自動で開きます。",
 	"cfg.general.rerunSetup": "Baochip が使用する uv と Python 環境を再インストールします。これは Baochip の初回使用時に自動的に実行されます。セットアップが失敗した場合や再構築したい場合に使用してください。[拡張機能のセットアップを再実行](command:baochip.rerunSetup)",
-
 	"cfg.title.ports": "Baochip - ポート",
 	"cfg.ports.bootloader": "ブートローダー / UF2 ドライブモードで現れるシリアルポート。",
 	"cfg.ports.run": "実行モード（通常のファームウェアログ）で使用するシリアルポート。",
 	"cfg.ports.monitorDefault": "モニターボタンが既定で使用するポート。",
-
 	"cfg.title.monitor": "Baochip - モニター",
 	"cfg.monitor.defaultBaud": "シリアルモニターの既定のボーレート。",
 	"cfg.monitor.crlf": "ラインモードで CRLF を送信行末に使用。",
 	"cfg.monitor.raw": "キー入力を即時送信（生モード）。",
 	"cfg.monitor.echo": "入力のローカルエコー。",
-
 	"cfg.title.build": "Baochip - ビルド",
 	"cfg.build.buildMode": "ビルドモード。'auto' はワークスペースから自動検出します（apps-dabao/ があれば xous-core モード、なければ out-of-tree）。特定のモードを強制するには上書きしてください。",
 	"cfg.build.target": "現在選択中のビルドターゲット（例：dabao、baosec）。インツリーおよびアウトオブツリービルドの両方でターゲットボードの選択に使用されます。",
-
 	"cfg.title.intree": "Baochip - インツリービルド（xous-core）",
 	"cfg.intree.xousCorePath": "ローカルの xous-core チェックアウト先（フォルダー）へのパス。インツリービルド（xous-core リポジトリ内でアプリをビルドする場合）にのみ必要です。",
-	"cfg.intree.appName": "xous-core/apps-dabao/ 配下の Baochip アプリ名。スペース区切りで複数指定可能（例：'helloworld demo_app'）。空の場合はターゲットのみをビルド。インツリービルドにのみ使用されます。",
-
+	"cfg.intree.appName": "ビルドするクレート (スペース区切り、例: 'helloworld demo_app')。xous-core ではアプリ、アウトオブツリーではワークスペースのクレート。xous-core で空欄にすると基本システムイメージのみ。",
 	"cfg.title.flashing": "Baochip - フラッシュ",
 	"cfg.title.outOfTree": "Baochip - アウトオブツリービルド",
 	"cfg.outOfTree.kernelMode": "out-of-tree フラッシュ用に loader.uf2 と xous.uf2 を取得する方法。アウトオブツリービルドにのみ使用されます。'ask' は初回セットアップダイアログを表示します。'ci-sync' は GitHub から最新の xous-core コミットを取得して Cargo.toml を更新し、CI から対応するカーネルファイルをダウンロードします。'manual' は baochip.outOfTree.kernelFilesPath で指定したフォルダのファイルを使用します。",
 	"cfg.outOfTree.kernelFilesPath": "手動 out-of-tree フラッシュ用の loader.uf2 と xous.uf2 が含まれるフォルダ。baochip.outOfTree.kernelMode が 'manual' の場合のみ使用されます。",
 	"cfg.outOfTree.extraFeatures": "アウトオブツリービルド用の追加 Cargo フィーチャーフラグ（標準の board-dabao/bao1x セットに加えて）（例：[\"usb\", \"my-feature\"]）。アウトオブツリービルドにのみ使用されます。",
 	"cfg.flashing.location": "マウントされた Baochip UF2 ドライブの場所（Windows では D:\\ または別のドライブレターのドライブ、macOS では /Volumes/BAOCHIP、Linux では /media/$(whoami)/BAOCHIP）。",
-
 	"views.container.title": "Baochip",
 	"views.main": "Baochip",
 	"views.docs": "ドキュメント",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,6 @@
 {
 	"ext.displayName": "Baochip",
 	"ext.description": "Develop, flash, and debug applications for Baochip microcontrollers in VS Code.",
-
 	"cmd.openWelcome": "Open Welcome",
 	"cmd.openSettings": "Open Settings",
 	"cmd.setBootPort": "Set Bootloader Mode's Serial Port",
@@ -23,37 +22,30 @@
 	"cmd.resetUvSetup": "Reset UV Setup",
 	"cmd.rerunSetup": "Re-run Extension Setup",
 	"cmd.collectDiagnostics": "Collect Diagnostics",
-
 	"cfg.title.general": "Baochip - General",
 	"cfg.general.showWelcomeOnStartup": "Automatically open the Baochip Welcome page when the extension activates.",
 	"cfg.general.rerunSetup": "Re-installs uv and the Python environment Baochip uses. This runs automatically the first time you use Baochip; use it to run setup again if it failed or you want to rebuild it. [Re-run Extension Setup](command:baochip.rerunSetup)",
-
 	"cfg.title.ports": "Baochip - Ports",
 	"cfg.ports.bootloader": "Serial port that appears in bootloader / UF2 drive mode.",
 	"cfg.ports.run": "Serial port used for run mode (normal firmware logs).",
 	"cfg.ports.monitorDefault": "Which port the Monitor button uses by default.",
-
 	"cfg.title.monitor": "Baochip - Monitor",
 	"cfg.monitor.defaultBaud": "Default baud rate for the serial monitor.",
 	"cfg.monitor.crlf": "Use CRLF as TX line ending in line mode.",
 	"cfg.monitor.raw": "Send keystrokes immediately (raw mode).",
 	"cfg.monitor.echo": "Local echo of typed input.",
-
 	"cfg.title.build": "Baochip - Build",
 	"cfg.build.buildMode": "Build mode. 'auto' detects from the workspace (xous-core mode if apps-dabao/ is present, otherwise out-of-tree). Override to force a specific mode.",
 	"cfg.build.target": "Currently selected build target (e.g., dabao, baosec). Used by both in-tree and out-of-tree builds to select the target board.",
-
 	"cfg.title.intree": "Baochip - In-tree Builds (xous-core)",
 	"cfg.intree.xousCorePath": "Path to your local xous-core checkout (folder). Only required for in-tree builds (when building apps inside the xous-core repository).",
-	"cfg.intree.appName": "Name of the Baochip app under xous-core/apps-dabao/. Multiple apps can be separated by spaces (e.g., 'helloworld demo_app'). Leave blank to build the target only. Only used for in-tree builds.",
-
+	"cfg.intree.appName": "Crates to build, space-separated (e.g. 'helloworld demo_app'). Apps in a xous-core checkout, workspace crates out-of-tree. Leave blank in xous-core for the base system image only.",
 	"cfg.title.flashing": "Baochip - Flashing",
 	"cfg.title.outOfTree": "Baochip - Out-of-Tree Builds",
 	"cfg.outOfTree.kernelMode": "How the extension sources loader.uf2 and xous.uf2 for out-of-tree flashing. Only used for out-of-tree builds. 'ask' shows a one-time setup prompt. 'ci-sync' fetches the latest xous-core rev from GitHub, updates Cargo.toml to match, then downloads matching kernel files from CI. 'manual' uses files from the folder set in baochip.outOfTree.kernelFilesPath.",
 	"cfg.outOfTree.kernelFilesPath": "Folder containing loader.uf2 and xous.uf2 for manual out-of-tree flashing. Only used when baochip.outOfTree.kernelMode is 'manual'.",
 	"cfg.outOfTree.extraFeatures": "Additional cargo feature flags for out-of-tree builds, beyond the standard board-dabao/bao1x set (e.g. [\"usb\", \"my-feature\"]). Only used for out-of-tree builds.",
 	"cfg.flashing.location": "Location of the mounted Baochip UF2 drive (D:\\ or another letter drive on Windows, /Volumes/BAOCHIP on MacOS, /media/$(whoami)/BAOCHIP on Linux).",
-
 	"views.container.title": "Baochip",
 	"views.main": "Baochip",
 	"views.docs": "Documentation",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,7 +1,6 @@
 {
 	"ext.displayName": "Baochip",
 	"ext.description": "在 VS Code 中开发、烧录并调试 Baochip 微控制器应用。",
-
 	"cmd.openWelcome": "打开欢迎页",
 	"cmd.openSettings": "打开设置",
 	"cmd.setBootPort": "设置引导模式串口",
@@ -23,37 +22,30 @@
 	"cmd.resetUvSetup": "重置 UV 设置",
 	"cmd.rerunSetup": "重新运行扩展设置",
 	"cmd.collectDiagnostics": "收集诊断信息",
-
 	"cfg.title.general": "Baochip - 常规",
 	"cfg.general.showWelcomeOnStartup": "扩展激活时自动打开 Baochip 欢迎页。",
 	"cfg.general.rerunSetup": "重新安装 Baochip 使用的 uv 和 Python 环境。首次使用 Baochip 时会自动运行；如果设置失败或想要重建，可使用此项再次运行。[重新运行扩展设置](command:baochip.rerunSetup)",
-
 	"cfg.title.ports": "Baochip - 端口",
 	"cfg.ports.bootloader": "在引导程序 / UF2 驱动器模式出现的串口。",
 	"cfg.ports.run": "运行模式（普通固件日志）下使用的串口。",
 	"cfg.ports.monitorDefault": "监视按钮默认使用的端口。",
-
 	"cfg.title.monitor": "Baochip - 监视器",
 	"cfg.monitor.defaultBaud": "串口监视器的默认波特率。",
 	"cfg.monitor.crlf": "行模式发送时使用 CRLF 作为行尾。",
 	"cfg.monitor.raw": "立即发送按键（原始模式）。",
 	"cfg.monitor.echo": "本地回显输入。",
-
 	"cfg.title.build": "Baochip - 构建",
 	"cfg.build.buildMode": "构建模式。'auto' 从工作区自动检测（若存在 apps-dabao/ 则为 xous-core 模式，否则为 out-of-tree）。可覆盖以强制指定模式。",
 	"cfg.build.target": "当前选择的构建目标（例如：dabao、baosec）。用于 in-tree 和 out-of-tree 构建的目标板选择。",
-
 	"cfg.title.intree": "Baochip - In-tree 构建（xous-core）",
 	"cfg.intree.xousCorePath": "本地 xous-core 检出文件夹路径。仅 in-tree 构建（在 xous-core 仓库内构建应用）时需要。",
-	"cfg.intree.appName": "xous-core/apps-dabao/ 下的 Baochip 应用名称。可用空格分隔多个（例如 'helloworld demo_app'），留空则仅构建目标。仅用于 in-tree 构建。",
-
+	"cfg.intree.appName": "要构建的 crate，空格分隔 (例如 'helloworld demo_app')。xous-core 中为应用，树外项目中为工作区 crate。在 xous-core 中留空则仅构建基础系统镜像。",
 	"cfg.title.flashing": "Baochip - 烧录",
 	"cfg.title.outOfTree": "Baochip - Out-of-Tree 构建",
 	"cfg.outOfTree.kernelMode": "扩展为 out-of-tree 烧录获取 loader.uf2 和 xous.uf2 的方式。仅用于 out-of-tree 构建。'ask' 首次显示设置提示。'ci-sync' 从 GitHub 获取最新 xous-core 提交并更新 Cargo.toml，然后从 CI 下载匹配的内核文件。'manual' 使用 baochip.outOfTree.kernelFilesPath 指定文件夹中的文件。",
 	"cfg.outOfTree.kernelFilesPath": "包含 loader.uf2 和 xous.uf2 的文件夹，用于手动 out-of-tree 烧录。仅在 baochip.outOfTree.kernelMode 为 'manual' 时使用。",
 	"cfg.outOfTree.extraFeatures": "out-of-tree 构建的额外 Cargo 特性标志，除标准 board-dabao/bao1x 集之外（例如 [\"usb\", \"my-feature\"]）。仅用于 out-of-tree 构建。",
 	"cfg.flashing.location": "已挂载的 Baochip UF2 驱动器位置（Windows 上为 D:\\ 或其他盘符的驱动器，macOS 上为 /Volumes/BAOCHIP，Linux 上为 /media/$(whoami)/BAOCHIP）。",
-
 	"views.container.title": "Baochip",
 	"views.main": "Baochip",
 	"views.docs": "文档",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -1,7 +1,6 @@
 {
 	"ext.displayName": "Baochip",
 	"ext.description": "在 VS Code 中開發、燒錄並偵錯 Baochip 微控制器應用程式。",
-
 	"cmd.openWelcome": "開啟歡迎頁",
 	"cmd.openSettings": "開啟設定",
 	"cmd.setBootPort": "設定開機模式串列埠",
@@ -23,37 +22,30 @@
 	"cmd.resetUvSetup": "重設 UV 設定",
 	"cmd.rerunSetup": "重新執行擴充功能設定",
 	"cmd.collectDiagnostics": "收集診斷資訊",
-
 	"cfg.title.general": "Baochip - 一般",
 	"cfg.general.showWelcomeOnStartup": "擴充功能啟用時自動開啟 Baochip 歡迎頁。",
 	"cfg.general.rerunSetup": "重新安裝 Baochip 使用的 uv 和 Python 環境。首次使用 Baochip 時會自動執行；如果設定失敗或想要重建，可使用此項再次執行。[重新執行擴充功能設定](command:baochip.rerunSetup)",
-
 	"cfg.title.ports": "Baochip - 埠",
 	"cfg.ports.bootloader": "在開機載入程式 / UF2 磁碟模式出現的串列埠。",
 	"cfg.ports.run": "執行模式（一般韌體日誌）所使用的串列埠。",
 	"cfg.ports.monitorDefault": "監視按鈕預設使用的埠。",
-
 	"cfg.title.monitor": "Baochip - 監視器",
 	"cfg.monitor.defaultBaud": "串列監視器的預設鮑率。",
 	"cfg.monitor.crlf": "行模式傳送時使用 CRLF 作為行尾。",
 	"cfg.monitor.raw": "立即傳送按鍵（原始模式）。",
 	"cfg.monitor.echo": "輸入的本地回顯。",
-
 	"cfg.title.build": "Baochip - 建置",
 	"cfg.build.buildMode": "建置模式。'auto' 從工作區自動偵測（若存在 apps-dabao/ 則為 xous-core 模式，否則為 out-of-tree）。可覆寫以強制指定模式。",
 	"cfg.build.target": "目前選擇的建置目標（例如：dabao、baosec）。In-tree 和 out-of-tree 建置均使用此設定選擇目標板。",
-
 	"cfg.title.intree": "Baochip - In-tree 建置（xous-core）",
 	"cfg.intree.xousCorePath": "本機 xous-core 檔案夾路徑。僅 in-tree 建置（在 xous-core 儲存庫內建置應用程式）時需要。",
-	"cfg.intree.appName": "xous-core/apps-dabao/ 底下的 Baochip 應用程式名稱。可用空白分隔多個（例如 'helloworld demo_app'），留白則僅建置目標。僅用於 in-tree 建置。",
-
+	"cfg.intree.appName": "要建置的 crate，空格分隔 (例如 'helloworld demo_app')。xous-core 中為應用程式，樹外專案中為工作區 crate。在 xous-core 中留空則僅建置基礎系統映像。",
 	"cfg.title.flashing": "Baochip - 燒錄",
 	"cfg.title.outOfTree": "Baochip - Out-of-Tree 建置",
 	"cfg.outOfTree.kernelMode": "擴充功能取得 out-of-tree 燒錄用 loader.uf2 和 xous.uf2 的方式。僅用於 out-of-tree 建置。'ask' 首次顯示設定提示。'ci-sync' 從 GitHub 取得最新 xous-core 提交並更新 Cargo.toml，再從 CI 下載對應核心檔案。'manual' 使用 baochip.outOfTree.kernelFilesPath 指定資料夾中的檔案。",
 	"cfg.outOfTree.kernelFilesPath": "包含 loader.uf2 和 xous.uf2 的資料夾，用於手動 out-of-tree 燒錄。僅在 baochip.outOfTree.kernelMode 為 'manual' 時使用。",
 	"cfg.outOfTree.extraFeatures": "out-of-tree 建置的額外 Cargo 功能旗標，除標準 board-dabao/bao1x 集之外（例如 [\"usb\", \"my-feature\"]）。僅用於 out-of-tree 建置。",
 	"cfg.flashing.location": "已掛載的 Baochip UF2 磁碟位置（Windows 上為 D:\\ 或其他磁碟代號的磁碟，macOS 上為 /Volumes/BAOCHIP，Linux 上為 /media/$(whoami)/BAOCHIP）。",
-
 	"views.container.title": "Baochip",
 	"views.main": "Baochip",
 	"views.docs": "文件",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -12,9 +12,9 @@ export function registerBuildCommand() {
 		const pre = await ensureBuildPrereqs();
 		if (!pre) return;
 		if (pre.mode === 'out-of-tree') {
-			const ok = await ensureOutOfTreeBuildSetup(pre.root);
+			const ok = await ensureOutOfTreeBuildSetup(pre.root, pre.crates);
 			if (!ok) return;
-			runOutOfTreeBuildInTerminal(pre.root);
+			runOutOfTreeBuildInTerminal(pre.root, pre.crates);
 		} else {
 			runBuildInTerminal(pre.root, pre.target, pre.app);
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import { Commands } from '@commands/commandIds';
-import { hasCrateChoice } from '@services/appService';
+import { hasCrateChoice, unknownAppNames } from '@services/appService';
 import {
 	getBootloaderSerialPort,
 	getBuildTargetOrDefault,
@@ -115,13 +115,21 @@ export async function activate(context: vscode.ExtensionContext) {
 		items.buildTarget.tooltip = vscode.l10n.t('Click to select build target');
 		items.buildTarget.show();
 
-		// Which crates get built - hidden when there is nothing to choose between
-		if (hasCrateChoice()) {
-			items.app.text = app ? `$(package) ${app}` : `$(package) ${vscode.l10n.t('App: (not set)')}`;
-			items.app.tooltip =
-				mode === 'xous-core'
-					? vscode.l10n.t('Click to select xous-core app')
-					: vscode.l10n.t('Click to select the crate to build');
+		// Which crates get built - hidden only when there is nothing to choose and nothing wrong
+		const unknownApps = unknownAppNames();
+		if (hasCrateChoice() || unknownApps.length > 0) {
+			if (unknownApps.length > 0) {
+				items.app.text = `$(warning) ${app}`;
+				items.app.tooltip = vscode.l10n.t('Not found in this project: {0}', unknownApps.join(', '));
+			} else {
+				items.app.text = app
+					? `$(package) ${app}`
+					: `$(package) ${vscode.l10n.t('App: (not set)')}`;
+				items.app.tooltip =
+					mode === 'xous-core'
+						? vscode.l10n.t('Click to select xous-core app')
+						: vscode.l10n.t('Click to select the crate to build');
+			}
 			items.app.show();
 		} else {
 			items.app.hide();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import { Commands } from '@commands/commandIds';
+import { hasCrateChoice } from '@services/appService';
 import {
 	getBootloaderSerialPort,
 	getBuildTargetOrDefault,
@@ -114,10 +115,13 @@ export async function activate(context: vscode.ExtensionContext) {
 		items.buildTarget.tooltip = vscode.l10n.t('Click to select build target');
 		items.buildTarget.show();
 
-		// App name - only relevant in xous-core mode
-		if (mode === 'xous-core') {
+		// Which crates get built - hidden when there is nothing to choose between
+		if (hasCrateChoice()) {
 			items.app.text = app ? `$(package) ${app}` : `$(package) ${vscode.l10n.t('App: (not set)')}`;
-			items.app.tooltip = vscode.l10n.t('Click to select xous-core app');
+			items.app.tooltip =
+				mode === 'xous-core'
+					? vscode.l10n.t('Click to select xous-core app')
+					: vscode.l10n.t('Click to select the crate to build');
 			items.app.show();
 		} else {
 			items.app.hide();

--- a/src/services/appService.ts
+++ b/src/services/appService.ts
@@ -1,9 +1,20 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { Commands } from '@commands/commandIds';
 import { BUILD_TARGETS, getAppsDir } from '@constants';
-import { getBuildTargetOrDefault, getXousAppName, setXousAppName } from '@services/configService';
+import {
+	getBuildTargetOrDefault,
+	getXousAppName,
+	getXousCorePath,
+	setXousAppName,
+} from '@services/configService';
 import { warn } from '@services/logService';
-import { getOutOfTreeRoot, getProjectMode } from '@services/projectModeService';
+import {
+	findOutOfTreeRoot,
+	findXousCoreInWorkspace,
+	getOutOfTreeRoot,
+	getProjectMode,
+} from '@services/projectModeService';
 import { getExtensionRoot } from '@services/uvService';
 import { ensureXousWorkspaceOpen } from '@services/workspaceService';
 import { resolveXousRootOrNotify } from '@services/xousCoreService';
@@ -22,9 +33,27 @@ import * as vscode from 'vscode';
 /** Whether there is a crate worth choosing between. Quiet: the status bar calls it on every refresh. */
 export function hasCrateChoice(): boolean {
 	if (getProjectMode() === 'xous-core') return true;
-	const folder = vscode.workspace.workspaceFolders?.[0];
-	if (!folder) return false;
-	return discoverOutOfTreeCrates(folder.uri.fsPath).crates.length > 1;
+	const root = findOutOfTreeRoot();
+	if (!root) return false;
+	return discoverOutOfTreeCrates(root).crates.length > 1;
+}
+
+/** Names in the setting matching no crate here. Empty when the crates cannot be determined. */
+export function unknownAppNames(): string[] {
+	const names = splitAppNames(getXousAppName());
+	if (names.length === 0) return [];
+
+	if (getProjectMode() === 'out-of-tree') {
+		const root = findOutOfTreeRoot();
+		if (!root) return [];
+		const known = discoverOutOfTreeCrates(root).crates.map((crate) => crate.name);
+		if (known.length === 0) return [];
+		return names.filter((name) => !known.includes(name));
+	}
+
+	const root = findXousCoreInWorkspace() || getXousCorePath();
+	if (!root) return [];
+	return missingApps(root, getXousAppName(), getBuildTargetOrDefault());
 }
 
 /** Crate names an out-of-tree project can build, warning about members it had to skip. */
@@ -122,6 +151,20 @@ async function promptAndSaveOutOfTreeCrate(): Promise<string | undefined> {
  * Returns undefined if nothing is available or the user cancels.
  */
 export async function promptAndSaveApp(): Promise<string | undefined> {
+	// picking would overwrite a setting the user may have meant
+	const unknown = unknownAppNames();
+	if (unknown.length > 0) {
+		const settingsLabel = vscode.l10n.t('Open Baochip Settings');
+		const choice = await vscode.window.showWarningMessage(
+			vscode.l10n.t('Not found in this project: {0}', unknown.join(', ')),
+			settingsLabel,
+		);
+		if (choice === settingsLabel) {
+			await vscode.commands.executeCommand(Commands.openSettings);
+		}
+		return undefined;
+	}
+
 	if (getProjectMode() === 'out-of-tree') return promptAndSaveOutOfTreeCrate();
 
 	const root = await resolveXousRootOrNotify();

--- a/src/services/appService.ts
+++ b/src/services/appService.ts
@@ -35,7 +35,9 @@ export function hasCrateChoice(): boolean {
 	if (getProjectMode() === 'xous-core') return true;
 	const root = findOutOfTreeRoot();
 	if (!root) return false;
-	return discoverOutOfTreeCrates(root).crates.length > 1;
+	const { crates, wildcardMembers, unreadableMembers } = discoverOutOfTreeCrates(root);
+	// Members we could not resolve still mean a choice exists - just one we cannot offer yet.
+	return crates.length > 1 || wildcardMembers.length > 0 || unreadableMembers.length > 0;
 }
 
 /** Names in the setting matching no crate here. Empty when the crates cannot be determined. */
@@ -83,11 +85,25 @@ export function listOutOfTreeCrates(root: string): string[] {
 /** Selected crates for an out-of-tree build; a lone crate is filled in without prompting. */
 export async function ensureOutOfTreeAppSelection(root: string): Promise<string[] | undefined> {
 	const selected = splitAppNames(getXousAppName());
-	if (selected.length > 0) return selected;
+	if (selected.length > 0) {
+		// Checked here so a stale name gets this message rather than cargo's package-ID error.
+		const unknown = unknownAppNames();
+		if (unknown.length > 0) {
+			vscode.window.showErrorMessage(
+				vscode.l10n.t('Not found in this project: {0}', unknown.join(', ')),
+			);
+			return undefined;
+		}
+		return selected;
+	}
 
 	const available = listOutOfTreeCrates(root);
 	if (available.length === 0) {
-		vscode.window.showErrorMessage(vscode.l10n.t('No crates found in {0}.', root));
+		// listOutOfTreeCrates already said why when it could; only add the vague message otherwise.
+		const { wildcardMembers, unreadableMembers } = discoverOutOfTreeCrates(root);
+		if (wildcardMembers.length === 0 && unreadableMembers.length === 0) {
+			vscode.window.showErrorMessage(vscode.l10n.t('No crates found in {0}.', root));
+		}
 		return undefined;
 	}
 

--- a/src/services/appService.ts
+++ b/src/services/appService.ts
@@ -7,6 +7,7 @@ import { getOutOfTreeRoot, getProjectMode } from '@services/projectModeService';
 import { getExtensionRoot } from '@services/uvService';
 import { ensureXousWorkspaceOpen } from '@services/workspaceService';
 import { resolveXousRootOrNotify } from '@services/xousCoreService';
+import { splitAppNames } from '@util/appName';
 import {
 	addWorkspaceMemberToToml,
 	discoverOutOfTreeCrates,
@@ -52,8 +53,8 @@ export function listOutOfTreeCrates(root: string): string[] {
 
 /** Selected crates for an out-of-tree build; a lone crate is filled in without prompting. */
 export async function ensureOutOfTreeAppSelection(root: string): Promise<string[] | undefined> {
-	const selected = getXousAppName().trim();
-	if (selected) return selected.split(/\s+/).filter(Boolean);
+	const selected = splitAppNames(getXousAppName());
+	if (selected.length > 0) return selected;
 
 	const available = listOutOfTreeCrates(root);
 	if (available.length === 0) {
@@ -67,7 +68,7 @@ export async function ensureOutOfTreeAppSelection(root: string): Promise<string[
 	}
 
 	const picked = await promptAndSaveApp();
-	return picked ? picked.split(/\s+/).filter(Boolean) : undefined;
+	return picked ? splitAppNames(picked) : undefined;
 }
 
 export async function listBaoApps(xousRoot: string, target: string): Promise<string[]> {
@@ -81,7 +82,28 @@ export async function listBaoApps(xousRoot: string, target: string): Promise<str
 		.sort((a, b) => a.localeCompare(b));
 }
 
-/** Pick one out-of-tree crate. Multi-select arrives with the picker rework. */
+/**
+ * Multi-select over `available`, pre-checked from the current setting and saved back
+ * space-separated. Selecting nothing leaves the setting alone rather than clearing it.
+ */
+async function pickAndSaveApps(
+	available: string[],
+	placeHolder: string,
+): Promise<string | undefined> {
+	const current = splitAppNames(getXousAppName());
+	const picked = await vscode.window.showQuickPick(
+		available.map((name) => ({ label: name, picked: current.includes(name) })),
+		{ placeHolder, canPickMany: true },
+	);
+	if (!picked || picked.length === 0) return undefined;
+
+	const selection = picked.map((item) => item.label).join(' ');
+	await setXousAppName(selection);
+	vscode.window.showInformationMessage(vscode.l10n.t('Baochip app set to: {0}', selection));
+	return selection;
+}
+
+/** Pick which crates an out-of-tree project builds. */
 async function promptAndSaveOutOfTreeCrate(): Promise<string | undefined> {
 	const root = getOutOfTreeRoot();
 	if (!root) return undefined;
@@ -92,19 +114,7 @@ async function promptAndSaveOutOfTreeCrate(): Promise<string | undefined> {
 		return undefined;
 	}
 
-	const current = getXousAppName();
-	const pick = await vscode.window.showQuickPick(
-		crates.map((name) => ({
-			label: name,
-			description: name === current ? vscode.l10n.t('current') : undefined,
-		})),
-		{ placeHolder: vscode.l10n.t('Select crate') },
-	);
-	if (!pick) return undefined;
-
-	await setXousAppName(pick.label);
-	vscode.window.showInformationMessage(vscode.l10n.t('Baochip app set to: {0}', pick.label));
-	return pick.label;
+	return pickAndSaveApps(crates, vscode.l10n.t('Select crate'));
 }
 
 /**
@@ -134,31 +144,15 @@ export async function promptAndSaveApp(): Promise<string | undefined> {
 		return undefined;
 	}
 
-	const current = getXousAppName();
-	const pick = await vscode.window.showQuickPick(
-		apps.map((a) => ({
-			label: a,
-			description: a === current ? vscode.l10n.t('current') : undefined,
-		})),
-		{ placeHolder: vscode.l10n.t('Select app') },
-	);
-	if (!pick) return undefined;
-
-	await setXousAppName(pick.label);
-	vscode.window.showInformationMessage(vscode.l10n.t('Baochip app set to: {0}', pick.label));
-	return pick.label;
+	return pickAndSaveApps(apps, vscode.l10n.t('Select app'));
 }
 
 export function missingApps(xousRoot: string, appNames: string, target: string): string[] {
 	const appsDir = path.join(xousRoot, getAppsDir(target));
-	return appNames
-		.trim()
-		.split(/\s+/)
-		.filter(Boolean)
-		.filter((n) => {
-			const dir = path.join(appsDir, n);
-			return !(isDirectory(dir) && hasCargoToml(dir));
-		});
+	return splitAppNames(appNames).filter((n) => {
+		const dir = path.join(appsDir, n);
+		return !(isDirectory(dir) && hasCargoToml(dir));
+	});
 }
 
 export function appExists(xousRoot: string, appNames: string, target: string): boolean {

--- a/src/services/appService.ts
+++ b/src/services/appService.ts
@@ -2,12 +2,14 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { BUILD_TARGETS, getAppsDir } from '@constants';
 import { getBuildTargetOrDefault, getXousAppName, setXousAppName } from '@services/configService';
-import { getProjectMode } from '@services/projectModeService';
+import { warn } from '@services/logService';
+import { getOutOfTreeRoot, getProjectMode } from '@services/projectModeService';
 import { getExtensionRoot } from '@services/uvService';
 import { ensureXousWorkspaceOpen } from '@services/workspaceService';
 import { resolveXousRootOrNotify } from '@services/xousCoreService';
 import {
 	addWorkspaceMemberToToml,
+	discoverOutOfTreeCrates,
 	parseWorkspaceMembers,
 	readCargoPackageName,
 	rewriteXousGitDepsToPaths,
@@ -15,6 +17,58 @@ import {
 } from '@util/cargo';
 import { hasCargoToml, isDirectory } from '@util/fsUtil';
 import * as vscode from 'vscode';
+
+/** Whether there is a crate worth choosing between. Quiet: the status bar calls it on every refresh. */
+export function hasCrateChoice(): boolean {
+	if (getProjectMode() === 'xous-core') return true;
+	const folder = vscode.workspace.workspaceFolders?.[0];
+	if (!folder) return false;
+	return discoverOutOfTreeCrates(folder.uri.fsPath).crates.length > 1;
+}
+
+/** Crate names an out-of-tree project can build, warning about members it had to skip. */
+export function listOutOfTreeCrates(root: string): string[] {
+	const { crates, wildcardMembers, unreadableMembers } = discoverOutOfTreeCrates(root);
+
+	if (wildcardMembers.length > 0) {
+		warn(
+			vscode.l10n.t(
+				'Workspace members using "*" are not supported: {0}. List each crate folder individually.',
+				wildcardMembers.join(', '),
+			),
+		);
+	}
+	if (unreadableMembers.length > 0) {
+		warn(
+			vscode.l10n.t(
+				'These workspace members have no readable Cargo.toml: {0}',
+				unreadableMembers.join(', '),
+			),
+		);
+	}
+
+	return crates.map((crate) => crate.name);
+}
+
+/** Selected crates for an out-of-tree build; a lone crate is filled in without prompting. */
+export async function ensureOutOfTreeAppSelection(root: string): Promise<string[] | undefined> {
+	const selected = getXousAppName().trim();
+	if (selected) return selected.split(/\s+/).filter(Boolean);
+
+	const available = listOutOfTreeCrates(root);
+	if (available.length === 0) {
+		vscode.window.showErrorMessage(vscode.l10n.t('No crates found in {0}.', root));
+		return undefined;
+	}
+
+	if (available.length === 1) {
+		await setXousAppName(available[0]);
+		return available;
+	}
+
+	const picked = await promptAndSaveApp();
+	return picked ? picked.split(/\s+/).filter(Boolean) : undefined;
+}
 
 export async function listBaoApps(xousRoot: string, target: string): Promise<string[]> {
 	const appsDir = path.join(xousRoot, getAppsDir(target));
@@ -27,12 +81,38 @@ export async function listBaoApps(xousRoot: string, target: string): Promise<str
 		.sort((a, b) => a.localeCompare(b));
 }
 
+/** Pick one out-of-tree crate. Multi-select arrives with the picker rework. */
+async function promptAndSaveOutOfTreeCrate(): Promise<string | undefined> {
+	const root = getOutOfTreeRoot();
+	if (!root) return undefined;
+
+	const crates = listOutOfTreeCrates(root);
+	if (crates.length === 0) {
+		vscode.window.showErrorMessage(vscode.l10n.t('No crates found in {0}.', root));
+		return undefined;
+	}
+
+	const current = getXousAppName();
+	const pick = await vscode.window.showQuickPick(
+		crates.map((name) => ({
+			label: name,
+			description: name === current ? vscode.l10n.t('current') : undefined,
+		})),
+		{ placeHolder: vscode.l10n.t('Select crate') },
+	);
+	if (!pick) return undefined;
+
+	await setXousAppName(pick.label);
+	vscode.window.showInformationMessage(vscode.l10n.t('Baochip app set to: {0}', pick.label));
+	return pick.label;
+}
+
 /**
- * Prompt the user to pick an app for the current xous-core workspace, persist it, and return it.
- * Returns undefined in out-of-tree mode, if no apps exist, or if the user cancels.
+ * Prompt the user to pick an app for the current project, persist it, and return it.
+ * Returns undefined if nothing is available or the user cancels.
  */
 export async function promptAndSaveApp(): Promise<string | undefined> {
-	if (getProjectMode() === 'out-of-tree') return undefined;
+	if (getProjectMode() === 'out-of-tree') return promptAndSaveOutOfTreeCrate();
 
 	const root = await resolveXousRootOrNotify();
 	if (!root) return undefined;

--- a/src/services/buildService.ts
+++ b/src/services/buildService.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 import { BUILD_TARGETS, getAppsDir, XOUS_TARGET_TRIPLE } from '@constants';
-import { appExists, missingApps } from '@services/appService';
+import { appExists, ensureOutOfTreeAppSelection, missingApps } from '@services/appService';
 import { appsUf2Path } from '@services/artifactsService';
 import {
 	getBuildTarget,
@@ -17,13 +17,13 @@ import { ensureNamedTerminal } from '@services/terminalService';
 import { ensureXousFolderOpen, resolveXousRootOrNotify } from '@services/xousCoreService';
 import { checkXousAppUf2 } from '@services/xousToolsService';
 import { isLikelyValidAppName } from '@util/appName';
-import { buildOutOfTreeFeatures, isValidCrateName, readCargoPackageName } from '@util/cargo';
+import { buildOutOfTreeFeatures, isValidCrateName } from '@util/cargo';
 import { quoteArg } from '@util/shell';
 import * as vscode from 'vscode';
 
 export type BuildPrereqs =
 	| { mode: 'xous-core'; root: string; target: string; app?: string }
-	| { mode: 'out-of-tree'; root: string };
+	| { mode: 'out-of-tree'; root: string; crates: string[] };
 
 /** Return the configured build target, prompting to select one if unset. Returns undefined if the user declines. */
 export async function ensureBuildTargetOrPrompt(): Promise<string | undefined> {
@@ -68,7 +68,10 @@ export async function ensureBuildPrereqs(): Promise<BuildPrereqs | undefined> {
 
 		const root = getOutOfTreeRoot();
 		if (!root) return;
-		return { mode: 'out-of-tree', root };
+
+		const crates = await ensureOutOfTreeAppSelection(root);
+		if (!crates || crates.length === 0) return;
+		return { mode: 'out-of-tree', root, crates };
 	}
 
 	const root = await resolveXousRootOrNotify();
@@ -152,42 +155,47 @@ function checkUf2SizeAfterBuild(term: vscode.Terminal, uf2Path: string): void {
 	pendingBuildWatch = stop;
 }
 
-/** Out-of-tree standalone build: open a terminal, build, then convert ELF to UF2. */
-export function runOutOfTreeBuildInTerminal(root: string) {
-	// The build target is a workspace-controlled setting interpolated into `board-${target}` on
-	// a shell command line; allow only known values so shell metacharacters never reach the
-	// terminal (quoteArg cannot make $ or backtick inert inside PowerShell double quotes).
-	// Empty is fine: it becomes the default board feature downstream.
+/** cargo args selecting only the crates to build, leaving other members alone. */
+function cratePackageArgs(crates: string[]): string[] {
+	return crates.flatMap((crate) => ['-p', crate]);
+}
+
+/** Each crate's ELF, relative to the root - a workspace shares one target directory. */
+function crateElfPaths(crates: string[]): string[] {
+	return crates.map((crate) => `target/${XOUS_TARGET_TRIPLE}/release/${crate}`);
+}
+
+/** Out-of-tree build in a terminal, chaining the UF2 conversion. */
+export function runOutOfTreeBuildInTerminal(root: string, crates: string[]) {
+	// Target and crate names reach a shell command line; allow only known-safe values, since
+	// quoteArg cannot make $ or backtick inert inside PowerShell double quotes.
 	const target = getBuildTarget();
 	if (target && !BUILD_TARGETS.includes(target)) {
 		vscode.window.showErrorMessage(vscode.l10n.t('Invalid build target: {0}', target));
 		return;
 	}
+	const badCrate = crates.find((crate) => !isValidCrateName(crate));
+	if (badCrate !== undefined) {
+		vscode.window.showErrorMessage(vscode.l10n.t('Invalid crate name: {0}', badCrate));
+		return;
+	}
 
 	const term = ensureNamedTerminal(vscode.l10n.t('Baochip Build'), root);
 
-	const buildCmd = `cargo build --release --target ${XOUS_TARGET_TRIPLE} ${outOfTreeFeatureArgs()
+	const buildArgs = [...cratePackageArgs(crates), ...outOfTreeFeatureArgs()];
+	const buildCmd = `cargo build --release --target ${XOUS_TARGET_TRIPLE} ${buildArgs
 		.map((a) => quoteArg(a))
 		.join(' ')}`;
 
-	// Read package name to construct ELF path for xous-app-uf2
-	const pkgName = readCargoPackageName(root);
-	// Only chain the UF2 step for a well-formed crate name: the value comes straight from
-	// the workspace's Cargo.toml, so anything else must not reach the command line.
-	if (pkgName && isValidCrateName(pkgName)) {
-		const elfPath = `target/${XOUS_TARGET_TRIPLE}/release/${pkgName}`;
-		const uf2Cmd = `xous-app-uf2 --elf ${quoteArg(elfPath)}`;
-		// PowerShell 5.x (shipped with Windows) does not support &&
-		const chainedCmd =
-			process.platform === 'win32'
-				? `${buildCmd}; if ($LASTEXITCODE -eq 0) { ${uf2Cmd} }`
-				: `${buildCmd} && ${uf2Cmd}`;
-		term.sendText(chainedCmd);
-		checkUf2SizeAfterBuild(term, appsUf2Path('out-of-tree', root));
-	} else {
-		// No UF2 step was chained, so this build produces no apps.uf2 to check.
-		term.sendText(buildCmd);
-	}
+	const uf2Args = crateElfPaths(crates).flatMap((elf) => ['--elf', elf]);
+	const uf2Cmd = `xous-app-uf2 ${uf2Args.map((a) => quoteArg(a)).join(' ')}`;
+	// PowerShell 5.x does not support &&
+	const chainedCmd =
+		process.platform === 'win32'
+			? `${buildCmd}; if ($LASTEXITCODE -eq 0) { ${uf2Cmd} }`
+			: `${buildCmd} && ${uf2Cmd}`;
+	term.sendText(chainedCmd);
+	checkUf2SizeAfterBuild(term, appsUf2Path('out-of-tree', root));
 
 	term.show(true);
 }
@@ -227,8 +235,9 @@ export function runBuildInTerminal(root: string, target: string, app?: string) {
 
 	announceBuilding(target, appArgs);
 	if (appArgs.length === 0) {
+		// quoted: PowerShell's echo prints each unquoted word on its own line
 		term.sendText(
-			`echo [bao] ${vscode.l10n.t('No apps specified - building target "{0}" only.', target)}`,
+			`echo ${quoteArg(`[bao] ${vscode.l10n.t('No apps specified - building target "{0}" only.', target)}`)}`,
 		);
 	}
 
@@ -291,8 +300,18 @@ async function runCargoAndWait(
 }
 
 /** Out-of-tree build: cargo build with fixed Baochip target and features. Returns exit code, or null when cancelled. */
-export async function runOutOfTreeBuildAndWait(root: string): Promise<number | null> {
-	const args = ['build', '--release', '--target', XOUS_TARGET_TRIPLE, ...outOfTreeFeatureArgs()];
+export async function runOutOfTreeBuildAndWait(
+	root: string,
+	crates: string[],
+): Promise<number | null> {
+	const args = [
+		'build',
+		'--release',
+		'--target',
+		XOUS_TARGET_TRIPLE,
+		...cratePackageArgs(crates),
+		...outOfTreeFeatureArgs(),
+	];
 	return runCargoAndWait(root, args);
 }
 

--- a/src/services/buildService.ts
+++ b/src/services/buildService.ts
@@ -16,7 +16,7 @@ import { checkRustToolchain } from '@services/rustCheckService';
 import { ensureNamedTerminal, runInTerminal } from '@services/terminalService';
 import { ensureXousFolderOpen, resolveXousRootOrNotify } from '@services/xousCoreService';
 import { checkXousAppUf2 } from '@services/xousToolsService';
-import { isLikelyValidAppName } from '@util/appName';
+import { isLikelyValidAppName, splitAppNames } from '@util/appName';
 import { buildOutOfTreeFeatures, isValidCrateName } from '@util/cargo';
 import { quoteArg } from '@util/shell';
 import * as vscode from 'vscode';
@@ -200,11 +200,6 @@ export async function runOutOfTreeBuildInTerminal(root: string, crates: string[]
 	term.show(true);
 }
 
-/** Split a whitespace-separated app string into individual app names (empty when none given). */
-function splitAppArgs(app?: string): string[] {
-	return app ? app.trim().split(/\s+/).filter(Boolean) : [];
-}
-
 /** Toast which target is being built, and whether any apps are included. */
 function announceBuilding(target: string, appArgs: string[]) {
 	vscode.window.showInformationMessage(
@@ -216,7 +211,7 @@ function announceBuilding(target: string, appArgs: string[]) {
 
 /** Standalone Build command UX: run in a VS Code terminal (non-blocking). */
 export async function runBuildInTerminal(root: string, target: string, app?: string) {
-	const appArgs = splitAppArgs(app);
+	const appArgs = splitAppNames(app);
 
 	// Target and app names are workspace-controlled settings interpolated into a shell command
 	// line; allow only known/identifier-like values so shell metacharacters never reach the
@@ -323,7 +318,7 @@ export async function runBuildAndWait(
 	target: string,
 	app?: string,
 ): Promise<number | null> {
-	const appArgs = splitAppArgs(app);
+	const appArgs = splitAppNames(app);
 	const args = ['xtask', target, ...appArgs];
 
 	announceBuilding(target, appArgs);

--- a/src/services/kernelService.ts
+++ b/src/services/kernelService.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { XOUS_CORE_REPO } from '@constants';
 import { runBaoCmd } from '@services/baoRunnerService';
 import {
 	getBuildTargetOrDefault,
@@ -12,6 +13,7 @@ import {
 import { downloadFile, fetchETag, fetchJson } from '@services/httpService';
 import { errorToast } from '@services/logService';
 import { getGlobalVenvRoot } from '@services/uvService';
+import { discoverOutOfTreeCrates } from '@util/cargo';
 import { toMessage } from '@util/error';
 import * as vscode from 'vscode';
 
@@ -252,7 +254,7 @@ export async function ensureKernelModeConfigured(): Promise<KernelMode | undefin
  * the latest xous-core rev to Cargo.toml before building.
  * Returns false if the user cancels or any step fails.
  */
-export async function ensureOutOfTreeBuildSetup(root: string): Promise<boolean> {
+export async function ensureOutOfTreeBuildSetup(root: string, crates: string[]): Promise<boolean> {
 	const kernelMode = await ensureKernelModeConfigured();
 	if (!kernelMode) return false;
 
@@ -264,18 +266,34 @@ export async function ensureOutOfTreeBuildSetup(root: string): Promise<boolean> 
 			toastRevFetchFailed(e);
 			return false;
 		}
-		try {
-			// quiet: this caller shows its own specific error toast below; without it runBaoCmd
-			// would also toast on failure, giving two toasts for one failed update-rev.
-			await runBaoCmd(
-				['app', 'update-rev', '--file', path.join(root, 'Cargo.toml'), '--rev', rev],
-				undefined,
-				{ quiet: true },
-			);
-		} catch (e: unknown) {
-			const message = toMessage(e);
-			errorToast(vscode.l10n.t('Failed to update xous-core rev in Cargo.toml: {0}', message));
-			return false;
+		// The root too: a workspace keeps its [patch] table there, where cargo honors it, and
+		// leaving it behind would drift the patched revision away from the members'.
+		const candidates = [
+			path.join(root, 'Cargo.toml'),
+			...discoverOutOfTreeCrates(root)
+				.crates.filter((crate) => crates.includes(crate.name))
+				.map((crate) => crate.manifestPath),
+		];
+		// update-rev errors on a manifest with no xous-core dependency, so skip those.
+		const manifests = [...new Set(candidates)].filter((manifest) => {
+			try {
+				return fs.readFileSync(manifest, 'utf8').includes(XOUS_CORE_REPO);
+			} catch {
+				return false;
+			}
+		});
+
+		for (const manifest of manifests) {
+			try {
+				// quiet: the caller's own toast below would otherwise be doubled
+				await runBaoCmd(['app', 'update-rev', '--file', manifest, '--rev', rev], undefined, {
+					quiet: true,
+				});
+			} catch (e: unknown) {
+				const message = toMessage(e);
+				errorToast(vscode.l10n.t('Failed to update xous-core rev in Cargo.toml: {0}', message));
+				return false;
+			}
 		}
 	}
 

--- a/src/services/pipelineService.ts
+++ b/src/services/pipelineService.ts
@@ -25,14 +25,14 @@ export async function runBuildFlashBoot(): Promise<boolean> {
 	if (!pre) return false;
 
 	if (pre.mode === 'out-of-tree') {
-		const ok = await ensureOutOfTreeBuildSetup(pre.root);
+		const ok = await ensureOutOfTreeBuildSetup(pre.root, pre.crates);
 		if (!ok) return false;
 	}
 
 	// 1) Build
 	const code =
 		pre.mode === 'out-of-tree'
-			? await runOutOfTreeBuildAndWait(pre.root)
+			? await runOutOfTreeBuildAndWait(pre.root, pre.crates)
 			: await runBuildAndWait(pre.root, pre.target, pre.app);
 	if (code === null) return false; // cancelled by the user - not a failure, no error toast
 	if (code !== 0) {
@@ -44,7 +44,7 @@ export async function runBuildFlashBoot(): Promise<boolean> {
 
 	// 1.5) ELF->UF2 conversion (out-of-tree only)
 	if (pre.mode === 'out-of-tree') {
-		const converted = await convertElfToUf2(pre.root);
+		const converted = await convertElfToUf2(pre.root, pre.crates);
 		if (!converted) return false;
 	}
 

--- a/src/services/projectModeService.ts
+++ b/src/services/projectModeService.ts
@@ -28,13 +28,18 @@ export function findXousCoreInWorkspace(): string | undefined {
  * Returns the root path of the first workspace folder for out-of-tree mode,
  * or shows an error and returns undefined if no folder is open.
  */
+/** The out-of-tree project root, or undefined. Quiet; use getOutOfTreeRoot to also report it. */
+export function findOutOfTreeRoot(): string | undefined {
+	return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+}
+
 export function getOutOfTreeRoot(): string | undefined {
-	const folder = vscode.workspace.workspaceFolders?.[0];
-	if (!folder) {
+	const root = findOutOfTreeRoot();
+	if (!root) {
 		vscode.window.showErrorMessage(vscode.l10n.t('No workspace folder open.'));
 		return undefined;
 	}
-	return folder.uri.fsPath;
+	return root;
 }
 
 /**

--- a/src/services/projectModeService.ts
+++ b/src/services/projectModeService.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ALL_APPS_DIRS } from '@constants';
 import { getBuildMode } from '@services/configService';
+import { discoverOutOfTreeCrates } from '@util/cargo';
 import { isDirectory } from '@util/fsUtil';
 import * as vscode from 'vscode';
 
@@ -81,11 +82,18 @@ export function isBaochipWorkspace(): boolean {
 	}
 
 	for (const folder of folders) {
-		const cargo = path.join(folder.uri.fsPath, 'Cargo.toml');
-		try {
-			if (fs.existsSync(cargo) && fs.readFileSync(cargo, 'utf8').includes('xous')) return true;
-		} catch {
-			// an unreadable Cargo.toml is not a relevance marker
+		const root = folder.uri.fsPath;
+		// A workspace root has no dependencies of its own; only the members mention xous.
+		const manifests = [
+			path.join(root, 'Cargo.toml'),
+			...discoverOutOfTreeCrates(root).crates.map((crate) => crate.manifestPath),
+		];
+		for (const cargo of manifests) {
+			try {
+				if (fs.existsSync(cargo) && fs.readFileSync(cargo, 'utf8').includes('xous')) return true;
+			} catch {
+				// an unreadable Cargo.toml is not a relevance marker
+			}
 		}
 	}
 	return false;

--- a/src/services/uf2ConvertService.ts
+++ b/src/services/uf2ConvertService.ts
@@ -4,20 +4,19 @@ import { XOUS_TARGET_TRIPLE } from '@constants';
 import { checkUf2Size } from '@services/flashService';
 import { appendSeparator, getBaochipChannel } from '@services/logService';
 import { runProcess } from '@services/procService';
-import { readCargoPackageName } from '@util/cargo';
 import * as vscode from 'vscode';
 
-export async function convertElfToUf2(root: string): Promise<boolean> {
-	const pkgName = readCargoPackageName(root);
-	if (!pkgName) {
-		vscode.window.showErrorMessage(vscode.l10n.t('Could not read package name from Cargo.toml.'));
-		return false;
-	}
-
-	const elfPath = path.join(root, 'target', XOUS_TARGET_TRIPLE, 'release', pkgName);
-	if (!fs.existsSync(elfPath)) {
+export async function convertElfToUf2(root: string, crates: string[]): Promise<boolean> {
+	const elfPaths = crates.map((crate) =>
+		path.join(root, 'target', XOUS_TARGET_TRIPLE, 'release', crate),
+	);
+	const missing = elfPaths.filter((elf) => !fs.existsSync(elf));
+	if (missing.length > 0) {
 		vscode.window.showErrorMessage(
-			vscode.l10n.t('ELF not found at {0}. Has the build completed successfully?', elfPath),
+			vscode.l10n.t(
+				'ELF not found at {0}. Has the build completed successfully?',
+				missing.join(', '),
+			),
 		);
 		return false;
 	}
@@ -34,11 +33,15 @@ export async function convertElfToUf2(root: string): Promise<boolean> {
 			cancellable: false,
 		},
 		async () => {
-			const r = await runProcess('xous-app-uf2', ['--elf', elfPath], {
-				cwd: root,
-				onStdout: (s) => chan.append(s),
-				onStderr: (s) => chan.append(s),
-			});
+			const r = await runProcess(
+				'xous-app-uf2',
+				elfPaths.flatMap((elf) => ['--elf', elf]),
+				{
+					cwd: root,
+					onStdout: (s) => chan.append(s),
+					onStderr: (s) => chan.append(s),
+				},
+			);
 			if (!r.error && r.code === 0) {
 				checkUf2Size(path.join(root, 'apps.uf2'));
 				return true;

--- a/src/test/integration/apps.test.ts
+++ b/src/test/integration/apps.test.ts
@@ -158,6 +158,36 @@ suite('App service and scaffolding', () => {
 		assert.equal(cfg().get<string>('xousAppName'), 'alpha zeta', 'selection not cleared');
 	});
 
+	test('promptAndSaveApp refuses to open when the setting names an unknown crate', async () => {
+		const root = makeFakeWorkspace(tmpDir(), ['one', 'two']);
+		await setCfg('buildMode', 'out-of-tree');
+		await setCfg('xousAppName', 'one ghost');
+		sandbox.stub(projectModeService, 'findOutOfTreeRoot').returns(root);
+		const warnings = sandbox.stub(
+			vscode.window,
+			'showWarningMessage',
+		) as unknown as sinon.SinonStub;
+		const pick = sandbox.stub(vscode.window, 'showQuickPick') as unknown as sinon.SinonStub;
+
+		const result = await appService.promptAndSaveApp();
+
+		assert.equal(result, undefined);
+		assert.ok(pick.notCalled, 'the picker never opens, so the setting is not overwritten');
+		assert.ok(
+			warnings.getCalls().some((c) => String(c.args[0]).includes('ghost')),
+			'the unknown name is reported',
+		);
+		assert.equal(cfg().get<string>('xousAppName'), 'one ghost', 'setting left untouched');
+	});
+
+	test('unknownAppNames stays quiet when the crates cannot be determined', async () => {
+		await setCfg('buildMode', 'out-of-tree');
+		await setCfg('xousAppName', 'anything');
+		sandbox.stub(projectModeService, 'findOutOfTreeRoot').returns(undefined);
+
+		assert.deepEqual(appService.unknownAppNames(), [], 'no folder means no verdict');
+	});
+
 	test('promptAndSaveApp lists apps from the adopted workspace root, not the configured one', async () => {
 		// The user adopts the currently-open folder; app listing must follow the returned root.
 		const { root: configuredRoot } = makeFakeXousCore(tmpDir(), { apps: ['configured_app'] });

--- a/src/test/integration/apps.test.ts
+++ b/src/test/integration/apps.test.ts
@@ -250,6 +250,41 @@ suite('App service and scaffolding', () => {
 		assert.ok(pick.notCalled, 'an existing selection is not re-asked');
 	});
 
+	test('ensureOutOfTreeAppSelection rejects a configured crate that does not exist', async () => {
+		const root = makeFakeWorkspace(tmpDir(), ['one', 'two']);
+		await setCfg('buildMode', 'out-of-tree');
+		await setCfg('xousAppName', 'one ghost');
+		sandbox.stub(projectModeService, 'findOutOfTreeRoot').returns(root);
+		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
+
+		const crates = await appService.ensureOutOfTreeAppSelection(root);
+
+		assert.equal(crates, undefined, 'the build stops before cargo sees the bad name');
+		assert.ok(
+			errors.getCalls().some((c) => String(c.args[0]).includes('ghost')),
+			'our message, not cargo package-ID error',
+		);
+	});
+
+	test('hasCrateChoice is true when a member cannot be resolved', async () => {
+		await setCfg('buildMode', 'out-of-tree');
+		const root = tmpDir();
+		fs.writeFileSync(
+			path.join(root, 'Cargo.toml'),
+			`[workspace]
+members = ["crates/*"]
+`,
+			'utf8',
+		);
+		sandbox.stub(projectModeService, 'findOutOfTreeRoot').returns(root);
+
+		assert.equal(
+			appService.hasCrateChoice(),
+			true,
+			'an unresolvable member still means the item should show, so the reason can be surfaced',
+		);
+	});
+
 	test('hasCrateChoice only where there is more than one crate', async () => {
 		await setCfg('buildMode', 'out-of-tree');
 		const solo = makeFakeWorkspace(tmpDir(), ['solo']);

--- a/src/test/integration/apps.test.ts
+++ b/src/test/integration/apps.test.ts
@@ -5,6 +5,7 @@ import { XOUS_CORE_REPO } from '@constants';
 import * as appService from '@services/appService';
 import * as kernelService from '@services/kernelService';
 import * as outOfTreeScaffoldService from '@services/outOfTreeScaffoldService';
+import * as projectModeService from '@services/projectModeService';
 import * as uvService from '@services/uvService';
 import * as workspaceService from '@services/workspaceService';
 import * as xousCoreService from '@services/xousCoreService';
@@ -14,6 +15,7 @@ import * as vscode from 'vscode';
 import {
 	activateExtension,
 	cleanupTmpDirs,
+	makeFakeWorkspace,
 	makeFakeXousCore,
 	resetBaochipConfig,
 	tmpDir,
@@ -65,14 +67,23 @@ suite('App service and scaffolding', () => {
 
 	/* ------------------------------ promptAndSaveApp ------------------------------ */
 
-	test('promptAndSaveApp returns undefined immediately in out-of-tree mode', async () => {
+	test('promptAndSaveApp offers the workspace crates in out-of-tree mode', async () => {
+		const root = makeFakeWorkspace(tmpDir(), ['one', 'two']);
 		await setCfg('buildMode', 'out-of-tree');
+		sandbox.stub(projectModeService, 'getOutOfTreeRoot').returns(root);
+		sandbox.stub(vscode.window, 'showInformationMessage');
 		const pick = sandbox.stub(vscode.window, 'showQuickPick') as unknown as sinon.SinonStub;
+		pick.resolves([{ label: 'one' }, { label: 'two' }]);
 
 		const result = await appService.promptAndSaveApp();
 
-		assert.equal(result, undefined);
-		assert.ok(pick.notCalled, 'no picker in out-of-tree mode');
+		assert.equal(result, 'one two', 'both crates saved space-separated');
+		assert.equal(cfg().get<string>('xousAppName'), 'one two');
+		const items = pick.firstCall.args[0] as { label: string }[];
+		assert.deepEqual(
+			items.map((i) => i.label),
+			['one', 'two'],
+		);
 	});
 
 	test('promptAndSaveApp warns when no apps exist', async () => {
@@ -94,7 +105,7 @@ suite('App service and scaffolding', () => {
 		);
 	});
 
-	test('promptAndSaveApp saves the pick and marks the current app', async () => {
+	test('promptAndSaveApp saves the pick and pre-checks the configured app', async () => {
 		const { root } = makeFakeXousCore(tmpDir(), { apps: ['zeta', 'alpha'] });
 		await setCfg('buildMode', 'xous-core');
 		await setCfg('xousAppName', 'zeta');
@@ -102,18 +113,49 @@ suite('App service and scaffolding', () => {
 		sandbox.stub(workspaceService, 'ensureXousWorkspaceOpen').resolves(root);
 		sandbox.stub(vscode.window, 'showInformationMessage');
 		const pick = sandbox.stub(vscode.window, 'showQuickPick') as unknown as sinon.SinonStub;
-		pick.resolves({ label: 'alpha' });
+		pick.resolves([{ label: 'alpha' }]);
 
 		const result = await appService.promptAndSaveApp();
 
 		assert.equal(result, 'alpha');
 		assert.equal(cfg().get<string>('xousAppName'), 'alpha');
-		const items = pick.firstCall.args[0] as { label: string; description?: string }[];
+		const items = pick.firstCall.args[0] as { label: string; picked?: boolean }[];
 		assert.deepEqual(
 			items.map((i) => i.label),
 			['alpha', 'zeta'],
 		);
-		assert.equal(items[1].description, 'current', 'configured app marked current');
+		assert.equal(items[1].picked, true, 'configured app starts checked');
+		assert.equal(pick.firstCall.args[1].canPickMany, true, 'multi-select');
+	});
+
+	test('promptAndSaveApp saves several apps space-separated', async () => {
+		const { root } = makeFakeXousCore(tmpDir(), { apps: ['alpha', 'zeta'] });
+		await setCfg('buildMode', 'xous-core');
+		sandbox.stub(xousCoreService, 'resolveXousRootOrNotify').resolves(root);
+		sandbox.stub(workspaceService, 'ensureXousWorkspaceOpen').resolves(root);
+		sandbox.stub(vscode.window, 'showInformationMessage');
+		const pick = sandbox.stub(vscode.window, 'showQuickPick') as unknown as sinon.SinonStub;
+		pick.resolves([{ label: 'alpha' }, { label: 'zeta' }]);
+
+		const result = await appService.promptAndSaveApp();
+
+		assert.equal(result, 'alpha zeta');
+		assert.equal(cfg().get<string>('xousAppName'), 'alpha zeta');
+	});
+
+	test('promptAndSaveApp leaves the setting alone when nothing is picked', async () => {
+		const { root } = makeFakeXousCore(tmpDir(), { apps: ['alpha', 'zeta'] });
+		await setCfg('buildMode', 'xous-core');
+		await setCfg('xousAppName', 'alpha zeta');
+		sandbox.stub(xousCoreService, 'resolveXousRootOrNotify').resolves(root);
+		sandbox.stub(workspaceService, 'ensureXousWorkspaceOpen').resolves(root);
+		const pick = sandbox.stub(vscode.window, 'showQuickPick') as unknown as sinon.SinonStub;
+		pick.resolves([]);
+
+		const result = await appService.promptAndSaveApp();
+
+		assert.equal(result, undefined);
+		assert.equal(cfg().get<string>('xousAppName'), 'alpha zeta', 'selection not cleared');
 	});
 
 	test('promptAndSaveApp lists apps from the adopted workspace root, not the configured one', async () => {

--- a/src/test/integration/apps.test.ts
+++ b/src/test/integration/apps.test.ts
@@ -209,6 +209,60 @@ suite('App service and scaffolding', () => {
 		);
 	});
 
+	/* ------------------------------ crate selection ------------------------------ */
+
+	test('ensureOutOfTreeAppSelection fills in a lone crate without prompting', async () => {
+		const root = makeFakeWorkspace(tmpDir(), ['solo']);
+		await setCfg('buildMode', 'out-of-tree');
+		const pick = sandbox.stub(vscode.window, 'showQuickPick') as unknown as sinon.SinonStub;
+
+		const crates = await appService.ensureOutOfTreeAppSelection(root);
+
+		assert.deepEqual(crates, ['solo']);
+		assert.equal(cfg().get<string>('xousAppName'), 'solo', 'written to the setting');
+		assert.ok(pick.notCalled, 'nothing to choose between, so nothing is asked');
+	});
+
+	test('ensureOutOfTreeAppSelection prompts when the project has several crates', async () => {
+		const root = makeFakeWorkspace(tmpDir(), ['one', 'two']);
+		await setCfg('buildMode', 'out-of-tree');
+		sandbox.stub(projectModeService, 'getOutOfTreeRoot').returns(root);
+		sandbox.stub(projectModeService, 'findOutOfTreeRoot').returns(root);
+		sandbox.stub(vscode.window, 'showInformationMessage');
+		const pick = sandbox.stub(vscode.window, 'showQuickPick') as unknown as sinon.SinonStub;
+		pick.resolves([{ label: 'two' }]);
+
+		const crates = await appService.ensureOutOfTreeAppSelection(root);
+
+		assert.deepEqual(crates, ['two']);
+		assert.ok(pick.calledOnce, 'the choice is put to the user');
+	});
+
+	test('ensureOutOfTreeAppSelection keeps a selection that is already set', async () => {
+		const root = makeFakeWorkspace(tmpDir(), ['one', 'two']);
+		await setCfg('buildMode', 'out-of-tree');
+		await setCfg('xousAppName', 'one two');
+		const pick = sandbox.stub(vscode.window, 'showQuickPick') as unknown as sinon.SinonStub;
+
+		const crates = await appService.ensureOutOfTreeAppSelection(root);
+
+		assert.deepEqual(crates, ['one', 'two']);
+		assert.ok(pick.notCalled, 'an existing selection is not re-asked');
+	});
+
+	test('hasCrateChoice only where there is more than one crate', async () => {
+		await setCfg('buildMode', 'out-of-tree');
+		const solo = makeFakeWorkspace(tmpDir(), ['solo']);
+		const several = makeFakeWorkspace(tmpDir(), ['one', 'two']);
+		const root = sandbox.stub(projectModeService, 'findOutOfTreeRoot');
+
+		root.returns(solo);
+		assert.equal(appService.hasCrateChoice(), false, 'one crate needs no picker');
+
+		root.returns(several);
+		assert.equal(appService.hasCrateChoice(), true);
+	});
+
 	/* ------------------------------ createBaoApp (real bundled template) ------------------------------ */
 
 	/** Every xous-core crate the dabao template depends on via git. */

--- a/src/test/integration/build.test.ts
+++ b/src/test/integration/build.test.ts
@@ -178,7 +178,7 @@ suite('Build service', () => {
 
 		const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 		assert.ok(wsRoot, 'test host has a workspace folder');
-		assert.deepEqual(pre, { mode: 'out-of-tree', root: wsRoot });
+		assert.deepEqual(pre, { mode: 'out-of-tree', root: wsRoot, crates: ['hello'] });
 	});
 
 	/* ------------------------------ runBuildAndWait / runOutOfTreeBuildAndWait ------------------------------ */
@@ -254,7 +254,7 @@ suite('Build service', () => {
 		await setCfg('buildTarget', 'dabao');
 		await setCfg('outOfTree.extraFeatures', ['foo', 'not a feature!']);
 
-		const code = await buildService.runOutOfTreeBuildAndWait('C:\\fake\\oot');
+		const code = await buildService.runOutOfTreeBuildAndWait('C:\\fake\\oot', ['hello']);
 
 		assert.equal(code, 0);
 		const [cmd, args, opts] = run.firstCall.args;
@@ -285,7 +285,7 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		const ensure = sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root);
+		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
 
 		assert.equal(ensure.firstCall.args[1], root, 'terminal cwd set via the API, not a typed cd');
 		assert.equal(sent.length, 1, `one chained command: ${sent.join(' | ')}`);
@@ -301,7 +301,7 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root);
+		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
 
 		assert.equal(sent.length, 1);
 		assert.ok(sent[0].includes(' && xous-app-uf2 --elf '), `POSIX && chain: ${sent[0]}`);
@@ -312,7 +312,7 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root);
+		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
 
 		assert.equal(sent.length, 1);
 		assert.ok(sent[0].includes('cargo build --release'), 'build command still sent');
@@ -325,7 +325,7 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root);
+		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
 
 		assert.equal(sent.length, 1);
 		assert.ok(sent[0].includes('cargo build --release'), 'build command still sent');
@@ -338,7 +338,7 @@ suite('Build service', () => {
 		const err = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 		const ensure = sandbox.stub(terminalService, 'ensureNamedTerminal');
 
-		buildService.runOutOfTreeBuildInTerminal(tmpDir());
+		buildService.runOutOfTreeBuildInTerminal(tmpDir(), ['hello']);
 
 		assert.ok(err.calledOnce, 'invalid target is surfaced to the user');
 		assert.ok(
@@ -354,7 +354,7 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root);
+		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
 
 		assert.equal(sent.length, 1);
 		assert.ok(sent[0].includes('board-baosec'), `known target passes through: ${sent[0]}`);

--- a/src/test/integration/build.test.ts
+++ b/src/test/integration/build.test.ts
@@ -29,11 +29,13 @@ const setCfg = (key: string, value: unknown) =>
 /** A successful, empty runProcess result. */
 const okRun = { code: 0, stdout: '', stderr: '', cancelled: false };
 
-/** A fake terminal capturing sendText calls, castable to vscode.Terminal. */
+/** A fake terminal capturing commands, castable to vscode.Terminal. Carries shell integration
+ * so runInTerminal resolves at once rather than waiting out its timeout. */
 function fakeTerminal() {
 	const sent: string[] = [];
 	const term = {
 		sendText: (t: string) => sent.push(t),
+		shellIntegration: { executeCommand: (t: string) => sent.push(t) },
 		show: () => {},
 	};
 	return { sent, term: term as unknown as vscode.Terminal };
@@ -169,16 +171,17 @@ suite('Build service', () => {
 		assert.ok(msg.includes('ghost, phantom'), `plural message lists all missing apps: ${msg}`);
 	});
 
-	test('ensureBuildPrereqs: out-of-tree mode returns the first workspace folder', async () => {
+	test('ensureBuildPrereqs: out-of-tree mode returns the folder and the selected crates', async () => {
 		sandbox.stub(rustCheckService, 'checkRustToolchain').resolves(true);
 		sandbox.stub(xousToolsService, 'checkXousAppUf2').resolves(true);
 		await setCfg('buildMode', 'out-of-tree');
+		await setCfg('xousAppName', 'alpha zeta');
 
 		const pre = await buildService.ensureBuildPrereqs();
 
 		const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 		assert.ok(wsRoot, 'test host has a workspace folder');
-		assert.deepEqual(pre, { mode: 'out-of-tree', root: wsRoot, crates: ['hello'] });
+		assert.deepEqual(pre, { mode: 'out-of-tree', root: wsRoot, crates: ['alpha', 'zeta'] });
 	});
 
 	/* ------------------------------ runBuildAndWait / runOutOfTreeBuildAndWait ------------------------------ */
@@ -264,6 +267,8 @@ suite('Build service', () => {
 			'--release',
 			'--target',
 			XOUS_TARGET_TRIPLE,
+			'-p',
+			'hello',
 			'--features',
 			'board-dabao',
 			'--features',
@@ -285,13 +290,13 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		const ensure = sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
+		await buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
 
 		assert.equal(ensure.firstCall.args[1], root, 'terminal cwd set via the API, not a typed cd');
 		assert.equal(sent.length, 1, `one chained command: ${sent.join(' | ')}`);
 		assert.ok(sent[0].includes(`cargo build --release --target ${XOUS_TARGET_TRIPLE}`));
 		assert.ok(sent[0].includes('; if ($LASTEXITCODE -eq 0) {'), 'PowerShell 5.x-safe chain');
-		assert.ok(sent[0].includes(`xous-app-uf2 --elf target/${XOUS_TARGET_TRIPLE}/release/myapp`));
+		assert.ok(sent[0].includes(`xous-app-uf2 --elf target/${XOUS_TARGET_TRIPLE}/release/hello`));
 	});
 
 	test('runOutOfTreeBuildInTerminal on POSIX chains build and UF2 via &&', async () => {
@@ -301,36 +306,37 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
+		await buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
 
 		assert.equal(sent.length, 1);
 		assert.ok(sent[0].includes(' && xous-app-uf2 --elf '), `POSIX && chain: ${sent[0]}`);
 	});
 
-	test('runOutOfTreeBuildInTerminal without a readable package name sends the build only', async () => {
-		const root = tmpDir(); // no Cargo.toml at all
+	test('runOutOfTreeBuildInTerminal passes one --elf per selected crate', async () => {
+		const root = tmpDir();
 		const { sent, term } = fakeTerminal();
 		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
+		await buildService.runOutOfTreeBuildInTerminal(root, ['alpha', 'zeta']);
 
 		assert.equal(sent.length, 1);
-		assert.ok(sent[0].includes('cargo build --release'), 'build command still sent');
-		assert.ok(!sent[0].includes('xous-app-uf2'), 'no UF2 chain without a package name');
+		assert.ok(sent[0].includes('-p alpha'), `alpha selected: ${sent[0]}`);
+		assert.ok(sent[0].includes('-p zeta'), `zeta selected: ${sent[0]}`);
+		assert.ok(sent[0].includes(`--elf target/${XOUS_TARGET_TRIPLE}/release/alpha`));
+		assert.ok(sent[0].includes(`--elf target/${XOUS_TARGET_TRIPLE}/release/zeta`));
 	});
 
-	test('runOutOfTreeBuildInTerminal skips the UF2 chain for a malformed crate name', async () => {
-		const root = tmpDir();
-		fs.writeFileSync(path.join(root, 'Cargo.toml'), '[package]\nname = "my;app $(x)"\n', 'utf8');
-		const { sent, term } = fakeTerminal();
-		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
+	test('runOutOfTreeBuildInTerminal rejects a malformed crate name before any terminal work', async () => {
+		const err = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
+		const ensure = sandbox.stub(terminalService, 'ensureNamedTerminal');
 
-		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
+		await buildService.runOutOfTreeBuildInTerminal(tmpDir(), ['my;app $(x)']);
 
-		assert.equal(sent.length, 1);
-		assert.ok(sent[0].includes('cargo build --release'), 'build command still sent');
-		assert.ok(!sent[0].includes('my;app'), 'malformed name never reaches the terminal');
-		assert.ok(!sent[0].includes('xous-app-uf2'), 'no UF2 chain');
+		assert.ok(ensure.notCalled, 'no terminal opened');
+		assert.ok(
+			err.getCalls().some((c) => String(c.args[0]).includes('Invalid crate name')),
+			'the malformed name is reported',
+		);
 	});
 
 	test('runOutOfTreeBuildInTerminal rejects a shell-active build target before any terminal work', async () => {
@@ -338,7 +344,7 @@ suite('Build service', () => {
 		const err = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 		const ensure = sandbox.stub(terminalService, 'ensureNamedTerminal');
 
-		buildService.runOutOfTreeBuildInTerminal(tmpDir(), ['hello']);
+		await buildService.runOutOfTreeBuildInTerminal(tmpDir(), ['hello']);
 
 		assert.ok(err.calledOnce, 'invalid target is surfaced to the user');
 		assert.ok(
@@ -354,7 +360,7 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
+		await buildService.runOutOfTreeBuildInTerminal(root, ['hello']);
 
 		assert.equal(sent.length, 1);
 		assert.ok(sent[0].includes('board-baosec'), `known target passes through: ${sent[0]}`);
@@ -390,7 +396,7 @@ suite('Build service', () => {
 		const { sent, term } = fakeTerminal();
 		sandbox.stub(terminalService, 'ensureNamedTerminal').returns(term);
 
-		buildService.runBuildInTerminal('C:\\fake\\root', 'dabao', 'hello world');
+		await buildService.runBuildInTerminal('C:\\fake\\root', 'dabao', 'hello world');
 
 		assert.deepEqual(sent, ['cargo xtask dabao hello world']);
 	});
@@ -399,7 +405,7 @@ suite('Build service', () => {
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 		const ensure = sandbox.stub(terminalService, 'ensureNamedTerminal');
 
-		buildService.runBuildInTerminal('C:\\fake\\root', 'dabao; rm -rf ~', 'hello');
+		await buildService.runBuildInTerminal('C:\\fake\\root', 'dabao; rm -rf ~', 'hello');
 
 		assert.ok(ensure.notCalled, 'no terminal opened');
 		assert.ok(String(errors.firstCall.args[0]).includes('Invalid build target'));
@@ -409,7 +415,7 @@ suite('Build service', () => {
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 		const ensure = sandbox.stub(terminalService, 'ensureNamedTerminal');
 
-		buildService.runBuildInTerminal('C:\\fake\\root', 'dabao', 'hello $(evil)');
+		await buildService.runBuildInTerminal('C:\\fake\\root', 'dabao', 'hello $(evil)');
 
 		assert.ok(ensure.notCalled, 'no terminal opened');
 		assert.ok(String(errors.firstCall.args[0]).includes('Invalid app name'));

--- a/src/test/integration/buildFlashBoot.test.ts
+++ b/src/test/integration/buildFlashBoot.test.ts
@@ -133,7 +133,7 @@ suite('Build-Flash-Boot pipeline', () => {
 
 	test('out-of-tree happy path adds kernel setup, UF2 convert, and kernel files to flash', async () => {
 		const p = stubPipeline(sandbox);
-		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT });
+		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT, crates: ['hello'] });
 
 		await runPipeline();
 
@@ -148,7 +148,7 @@ suite('Build-Flash-Boot pipeline', () => {
 
 	test('out-of-tree: a failed UF2 conversion stops before flash', async () => {
 		const p = stubPipeline(sandbox);
-		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT });
+		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT, crates: ['hello'] });
 		p.convert.resolves(false);
 
 		await runPipeline();
@@ -159,7 +159,7 @@ suite('Build-Flash-Boot pipeline', () => {
 
 	test('out-of-tree: a failed kernel setup stops before build', async () => {
 		const p = stubPipeline(sandbox);
-		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT });
+		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT, crates: ['hello'] });
 		p.kernelSetup.resolves(false);
 
 		await runPipeline();

--- a/src/test/integration/buildFlashMonitor.test.ts
+++ b/src/test/integration/buildFlashMonitor.test.ts
@@ -185,7 +185,7 @@ suite('Build-Flash-Monitor pipeline', () => {
 
 	test('out-of-tree happy path adds kernel setup, UF2 convert, and kernel files to flash', async () => {
 		const p = stubPipeline(sandbox);
-		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT });
+		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT, crates: ['hello'] });
 
 		await runPipeline(clock);
 
@@ -199,7 +199,7 @@ suite('Build-Flash-Monitor pipeline', () => {
 
 	test('out-of-tree: a failed UF2 conversion stops before flash', async () => {
 		const p = stubPipeline(sandbox);
-		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT });
+		p.prereqs.resolves({ mode: 'out-of-tree', root: OOT_ROOT, crates: ['hello'] });
 		p.convert.resolves(false);
 
 		await runPipeline(clock);

--- a/src/test/integration/helpers.ts
+++ b/src/test/integration/helpers.ts
@@ -118,6 +118,30 @@ export function makeFakeXousCore(root: string, opts: FakeXousCoreOptions = {}): 
 	return { root, appsDir, releaseDir };
 }
 
+/**
+ * An out-of-tree cargo workspace: a virtual root listing `crates`, each under apps/.
+ * Members are written in the given order, which is the order discovery returns them in.
+ */
+export function makeFakeWorkspace(root: string, crates: string[]): string {
+	for (const crate of crates) {
+		const dir = path.join(root, 'apps', crate);
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, 'Cargo.toml'),
+			`[package]\nname = "${crate}"\nversion = "0.1.0"\nedition = "2021"\n`,
+			'utf8',
+		);
+	}
+
+	const members = crates.map((c) => `  "apps/${c}",`).join('\n');
+	fs.writeFileSync(
+		path.join(root, 'Cargo.toml'),
+		`[workspace]\nmembers = [\n${members}\n]\n`,
+		'utf8',
+	);
+	return root;
+}
+
 /** Start of the dabao detached-app region, and the largest apps.uf2 that fits it. */
 export const DABAO_APP_START = 0x602f_fd00;
 export const DABAO_APP_UF2_LIMIT = 1787392;

--- a/src/test/integration/kernel.test.ts
+++ b/src/test/integration/kernel.test.ts
@@ -487,6 +487,54 @@ suite('Kernel files service', () => {
 		]);
 	});
 
+	test('ensureOutOfTreeBuildSetup (ci-sync) updates only the selected crates', async () => {
+		await setCfg('outOfTree.kernelMode', 'ci-sync');
+		sandbox.stub(httpService, 'fetchJson').resolves({ sha: SHA });
+		const runBao = sandbox.stub(baoRunnerService, 'runBaoCmd').resolves('');
+
+		const root = tmpDir();
+		fs.writeFileSync(path.join(root, 'Cargo.toml'), `[workspace]\nmembers = ["a", "b"]\n`, 'utf8');
+		for (const name of ['a', 'b']) {
+			fs.mkdirSync(path.join(root, name), { recursive: true });
+			fs.writeFileSync(
+				path.join(root, name, 'Cargo.toml'),
+				`[package]
+name = "${name}"
+
+[dependencies]
+bao1x-api = { git = "${XOUS_CORE_REPO}", rev = "old" }
+`,
+				'utf8',
+			);
+		}
+
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(root, ['a']);
+
+		assert.equal(ok, true);
+		const files = runBao.getCalls().map((c) => (c.args[0] as string[])[3]);
+		assert.deepEqual(files, [path.join(root, 'a', 'Cargo.toml')], 'only the selected crate');
+	});
+
+	test('ensureOutOfTreeBuildSetup (ci-sync) skips a crate with no xous-core dependency', async () => {
+		await setCfg('outOfTree.kernelMode', 'ci-sync');
+		sandbox.stub(httpService, 'fetchJson').resolves({ sha: SHA });
+		const runBao = sandbox.stub(baoRunnerService, 'runBaoCmd').resolves('');
+
+		const root = tmpDir();
+		fs.writeFileSync(path.join(root, 'Cargo.toml'), `[workspace]\nmembers = ["plain"]\n`, 'utf8');
+		fs.mkdirSync(path.join(root, 'plain'), { recursive: true });
+		fs.writeFileSync(
+			path.join(root, 'plain', 'Cargo.toml'),
+			`[package]\nname = "plain"\n\n[dependencies]\nlog = "0.4"\n`,
+			'utf8',
+		);
+
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(root, ['plain']);
+
+		assert.equal(ok, true, 'nothing to update is success, not failure');
+		assert.ok(runBao.notCalled, 'update-rev would error on a manifest with no xous-core dep');
+	});
+
 	test('ensureOutOfTreeBuildSetup (ci-sync) fails when the rev fetch fails', async () => {
 		await setCfg('outOfTree.kernelMode', 'ci-sync');
 		sandbox.stub(httpService, 'fetchJson').rejects(new Error('offline'));

--- a/src/test/integration/kernel.test.ts
+++ b/src/test/integration/kernel.test.ts
@@ -445,7 +445,7 @@ suite('Kernel files service', () => {
 		const fetchJson = sandbox.stub(httpService, 'fetchJson');
 		const runBao = sandbox.stub(baoRunnerService, 'runBaoCmd');
 
-		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir());
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir(), ['hello']);
 
 		assert.equal(ok, true);
 		assert.ok(fetchJson.notCalled && runBao.notCalled, 'no rev fetch or Cargo.toml update');
@@ -457,7 +457,7 @@ suite('Kernel files service', () => {
 		const runBao = sandbox.stub(baoRunnerService, 'runBaoCmd').resolves('');
 		const root = tmpDir();
 
-		const ok = await kernelService.ensureOutOfTreeBuildSetup(root);
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(root, ['hello']);
 
 		assert.equal(ok, true);
 		assert.deepEqual(runBao.firstCall.args[0], [
@@ -476,7 +476,7 @@ suite('Kernel files service', () => {
 		const runBao = sandbox.stub(baoRunnerService, 'runBaoCmd');
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 
-		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir());
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir(), ['hello']);
 
 		assert.equal(ok, false);
 		assert.ok(runBao.notCalled, 'no Cargo.toml update after a failed fetch');
@@ -494,7 +494,7 @@ suite('Kernel files service', () => {
 		sandbox.stub(baoRunnerService, 'runBaoCmd').rejects(new Error('no dependency found'));
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 
-		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir());
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir(), ['hello']);
 
 		assert.equal(ok, false);
 		assert.ok(
@@ -515,7 +515,7 @@ suite('Kernel files service', () => {
 			.resolves({ code: 2, stdout: '', stderr: 'no dependency found', cancelled: false });
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 
-		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir());
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir(), ['hello']);
 
 		assert.equal(ok, false);
 		assert.equal(

--- a/src/test/integration/kernel.test.ts
+++ b/src/test/integration/kernel.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { XOUS_CORE_REPO } from '@constants';
 import * as baoRunnerService from '@services/baoRunnerService';
 import * as httpService from '@services/httpService';
 import * as kernelService from '@services/kernelService';
@@ -30,6 +31,22 @@ function kernelCacheDir(): string {
 
 function wipeKernelCache(): void {
 	fs.rmSync(kernelCacheDir(), { recursive: true, force: true });
+}
+
+/** An out-of-tree root whose manifest pins xous-core, so the rev sync has something to update. */
+function ootRootWithXousDep(): string {
+	const root = tmpDir();
+	fs.writeFileSync(
+		path.join(root, 'Cargo.toml'),
+		`[package]
+name = "hello"
+
+[dependencies]
+bao1x-api = { git = "${XOUS_CORE_REPO}", rev = "old" }
+`,
+		'utf8',
+	);
+	return root;
 }
 
 suite('Kernel files service', () => {
@@ -455,7 +472,7 @@ suite('Kernel files service', () => {
 		await setCfg('outOfTree.kernelMode', 'ci-sync');
 		sandbox.stub(httpService, 'fetchJson').resolves({ sha: SHA });
 		const runBao = sandbox.stub(baoRunnerService, 'runBaoCmd').resolves('');
-		const root = tmpDir();
+		const root = ootRootWithXousDep();
 
 		const ok = await kernelService.ensureOutOfTreeBuildSetup(root, ['hello']);
 
@@ -494,7 +511,7 @@ suite('Kernel files service', () => {
 		sandbox.stub(baoRunnerService, 'runBaoCmd').rejects(new Error('no dependency found'));
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 
-		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir(), ['hello']);
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(ootRootWithXousDep(), ['hello']);
 
 		assert.equal(ok, false);
 		assert.ok(
@@ -515,7 +532,7 @@ suite('Kernel files service', () => {
 			.resolves({ code: 2, stdout: '', stderr: 'no dependency found', cancelled: false });
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 
-		const ok = await kernelService.ensureOutOfTreeBuildSetup(tmpDir(), ['hello']);
+		const ok = await kernelService.ensureOutOfTreeBuildSetup(ootRootWithXousDep(), ['hello']);
 
 		assert.equal(ok, false);
 		assert.equal(

--- a/src/test/integration/uf2Convert.test.ts
+++ b/src/test/integration/uf2Convert.test.ts
@@ -19,13 +19,12 @@ import {
 	writeUf2,
 } from './helpers';
 
-/** A fake out-of-tree project: a Cargo.toml package name plus a built ELF for that package. */
-function fakeOotProject(pkgName: string): string {
+/** A fake out-of-tree project with a built ELF for each named crate. */
+function fakeOotProject(crates: string[]): string {
 	const root = tmpDir();
-	fs.writeFileSync(path.join(root, 'Cargo.toml'), `[package]\nname = "${pkgName}"\n`, 'utf8');
 	const releaseDir = path.join(root, 'target', XOUS_TARGET_TRIPLE, 'release');
 	fs.mkdirSync(releaseDir, { recursive: true });
-	fs.writeFileSync(path.join(releaseDir, pkgName), 'ELF', 'utf8');
+	for (const crate of crates) fs.writeFileSync(path.join(releaseDir, crate), 'ELF', 'utf8');
 	return root;
 }
 
@@ -42,7 +41,7 @@ suite('UF2 conversion', () => {
 	});
 
 	test('convertElfToUf2 records a spawn failure in the output channel, not just a toast', async () => {
-		const root = fakeOotProject('my_oot_app');
+		const root = fakeOotProject(['my_oot_app']);
 		// A spawn failure never streams stdout/stderr, so the "See output" toast would otherwise
 		// point at a channel with no failure detail.
 		sandbox.stub(procService, 'runProcess').resolves({
@@ -56,7 +55,7 @@ suite('UF2 conversion', () => {
 		sandbox.stub(logService, 'getBaochipChannel').returns(chan);
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 
-		const ok = await convertElfToUf2(root, ['hello']);
+		const ok = await convertElfToUf2(root, ['my_oot_app']);
 
 		assert.equal(ok, false);
 		assert.ok(
@@ -70,7 +69,7 @@ suite('UF2 conversion', () => {
 	});
 
 	test('convertElfToUf2 returns true on a successful conversion', async () => {
-		const root = fakeOotProject('my_oot_app');
+		const root = fakeOotProject(['my_oot_app']);
 		sandbox.stub(procService, 'runProcess').resolves({
 			code: 0,
 			stdout: '',
@@ -78,11 +77,11 @@ suite('UF2 conversion', () => {
 			cancelled: false,
 		});
 
-		assert.equal(await convertElfToUf2(root, ['hello']), true);
+		assert.equal(await convertElfToUf2(root, ['my_oot_app']), true);
 	});
 
 	test('convertElfToUf2 warns at build time when the app overflows the dabao app region', async () => {
-		const root = fakeOotProject('my_oot_app');
+		const root = fakeOotProject(['my_oot_app']);
 		await vscode.workspace
 			.getConfiguration('baochip')
 			.update('buildTarget', 'dabao', vscode.ConfigurationTarget.Workspace);
@@ -97,7 +96,7 @@ suite('UF2 conversion', () => {
 			'showWarningMessage',
 		) as unknown as sinon.SinonStub;
 
-		const ok = await convertElfToUf2(root, ['hello']);
+		const ok = await convertElfToUf2(root, ['my_oot_app']);
 
 		assert.equal(ok, true, 'the conversion itself succeeded; the size warning is advisory');
 		assert.ok(

--- a/src/test/integration/uf2Convert.test.ts
+++ b/src/test/integration/uf2Convert.test.ts
@@ -56,7 +56,7 @@ suite('UF2 conversion', () => {
 		sandbox.stub(logService, 'getBaochipChannel').returns(chan);
 		const errors = sandbox.stub(vscode.window, 'showErrorMessage') as unknown as sinon.SinonStub;
 
-		const ok = await convertElfToUf2(root);
+		const ok = await convertElfToUf2(root, ['hello']);
 
 		assert.equal(ok, false);
 		assert.ok(
@@ -78,7 +78,7 @@ suite('UF2 conversion', () => {
 			cancelled: false,
 		});
 
-		assert.equal(await convertElfToUf2(root), true);
+		assert.equal(await convertElfToUf2(root, ['hello']), true);
 	});
 
 	test('convertElfToUf2 warns at build time when the app overflows the dabao app region', async () => {
@@ -97,7 +97,7 @@ suite('UF2 conversion', () => {
 			'showWarningMessage',
 		) as unknown as sinon.SinonStub;
 
-		const ok = await convertElfToUf2(root);
+		const ok = await convertElfToUf2(root, ['hello']);
 
 		assert.equal(ok, true, 'the conversion itself succeeded; the size warning is advisory');
 		assert.ok(

--- a/src/test/unit/appName.test.ts
+++ b/src/test/unit/appName.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { isLikelyValidAppName } from '../../util/appName';
+import { isLikelyValidAppName, splitAppNames } from '../../util/appName';
 
 test('isLikelyValidAppName: accepts lowercase names starting with a letter', () => {
 	for (const name of ['app', 'test_app', 'my-app', 'a1', 'x_2-y']) {
@@ -18,4 +18,22 @@ test('isLikelyValidAppName: rejects empty and illegal characters', () => {
 	for (const name of ['', 'my app', 'app!', 'app.name', 'app/name', 'café']) {
 		assert.equal(isLikelyValidAppName(name), false, name);
 	}
+});
+
+test('splitAppNames: splits on any run of whitespace', () => {
+	assert.deepEqual(splitAppNames('alpha  zeta\tbeta'), ['alpha', 'zeta', 'beta']);
+});
+
+test('splitAppNames: trims and ignores empty input', () => {
+	assert.deepEqual(splitAppNames('  hello  '), ['hello']);
+	assert.deepEqual(splitAppNames(''), []);
+	assert.deepEqual(splitAppNames('   '), []);
+	assert.deepEqual(splitAppNames(undefined), []);
+});
+
+test('splitAppNames: keeps a region suffix intact', () => {
+	assert.deepEqual(splitAppNames('dc34-console~flash dc34-vault'), [
+		'dc34-console~flash',
+		'dc34-vault',
+	]);
 });

--- a/src/test/unit/cargo.test.ts
+++ b/src/test/unit/cargo.test.ts
@@ -6,6 +6,9 @@ import { test } from 'node:test';
 import {
 	addWorkspaceMemberToToml,
 	buildOutOfTreeFeatures,
+	discoverOutOfTreeCrates,
+	hasPackageTable,
+	hasWorkspaceTable,
 	isValidCrateName,
 	isValidFeatureName,
 	parseCargoPackageName,
@@ -275,4 +278,157 @@ test('rewriteXousGitDepsToPaths: leaves other git repos and registry deps untouc
 	const { toml, missing } = rewriteXousGitDepsToPaths(cargo, PKG_MAP, '/xc/apps-dabao/a', '/xc');
 	assert.deepEqual(missing, []);
 	assert.equal(toml, cargo, 'nothing rewritten');
+});
+
+/* ------------------------------ workspace / package tables ------------------------------ */
+
+test('hasWorkspaceTable / hasPackageTable: plain package project', () => {
+	const toml = '[package]\nname = "solo"\n';
+	assert.equal(hasPackageTable(toml), true);
+	assert.equal(hasWorkspaceTable(toml), false);
+});
+
+test('hasWorkspaceTable / hasPackageTable: workspace with no root crate', () => {
+	const toml = '[workspace]\nmembers = ["a"]\n';
+	assert.equal(hasPackageTable(toml), false);
+	assert.equal(hasWorkspaceTable(toml), true);
+});
+
+test('hasWorkspaceTable: a commented-out table does not count', () => {
+	assert.equal(hasWorkspaceTable('# [workspace]\n[package]\nname = "x"\n'), false);
+});
+
+test('hasWorkspaceTable: [workspace.package] is not [workspace]', () => {
+	assert.equal(hasWorkspaceTable('[workspace.package]\nedition = "2021"\n'), false);
+});
+
+/* ------------------------------ discoverOutOfTreeCrates ------------------------------ */
+
+/** Build a temp project tree: files is a map of relative path -> contents. */
+function withProject(files: Record<string, string>, run: (dir: string) => void): void {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bao-crates-'));
+	try {
+		for (const [rel, body] of Object.entries(files)) {
+			const full = path.join(dir, rel);
+			fs.mkdirSync(path.dirname(full), { recursive: true });
+			fs.writeFileSync(full, body);
+		}
+		run(dir);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+test('discoverOutOfTreeCrates: plain package project yields its one crate', () => {
+	withProject({ 'Cargo.toml': '[package]\nname = "solo_app"\n' }, (dir) => {
+		const { crates, wildcardMembers, unreadableMembers } = discoverOutOfTreeCrates(dir);
+		assert.deepEqual(
+			crates.map((c) => c.name),
+			['solo_app'],
+		);
+		assert.equal(crates[0].manifestPath, path.join(dir, 'Cargo.toml'));
+		assert.deepEqual(wildcardMembers, []);
+		assert.deepEqual(unreadableMembers, []);
+	});
+});
+
+test('discoverOutOfTreeCrates: workspace with no root crate yields one entry per member', () => {
+	withProject(
+		{
+			'Cargo.toml': '[workspace]\nmembers = ["crates/alpha", "crates/beta"]\n',
+			'crates/alpha/Cargo.toml': '[package]\nname = "alpha"\n',
+			'crates/beta/Cargo.toml': '[package]\nname = "beta"\n',
+		},
+		(dir) => {
+			const { crates, unreadableMembers } = discoverOutOfTreeCrates(dir);
+			assert.deepEqual(
+				crates.map((c) => c.name),
+				['alpha', 'beta'],
+			);
+			assert.equal(crates[0].manifestPath, path.join(dir, 'crates/alpha', 'Cargo.toml'));
+			assert.deepEqual(unreadableMembers, []);
+		},
+	);
+});
+
+test('discoverOutOfTreeCrates: a root package is a member of its own workspace', () => {
+	withProject(
+		{
+			'Cargo.toml': '[package]\nname = "root_app"\n\n[workspace]\nmembers = ["helper"]\n',
+			'helper/Cargo.toml': '[package]\nname = "helper"\n',
+		},
+		(dir) => {
+			const { crates } = discoverOutOfTreeCrates(dir);
+			assert.deepEqual(
+				crates.map((c) => c.name),
+				['root_app', 'helper'],
+			);
+		},
+	);
+});
+
+test('discoverOutOfTreeCrates: a root crate listed in its own members is not returned twice', () => {
+	withProject(
+		{ 'Cargo.toml': '[package]\nname = "root_app"\n\n[workspace]\nmembers = ["."]\n' },
+		(dir) => {
+			const { crates } = discoverOutOfTreeCrates(dir);
+			assert.deepEqual(
+				crates.map((c) => c.name),
+				['root_app'],
+			);
+		},
+	);
+});
+
+test('discoverOutOfTreeCrates: wildcard members are reported, not expanded', () => {
+	withProject(
+		{
+			'Cargo.toml': '[workspace]\nmembers = ["crates/*", "tools/one"]\n',
+			'crates/alpha/Cargo.toml': '[package]\nname = "alpha"\n',
+			'tools/one/Cargo.toml': '[package]\nname = "one"\n',
+		},
+		(dir) => {
+			const { crates, wildcardMembers } = discoverOutOfTreeCrates(dir);
+			assert.deepEqual(
+				crates.map((c) => c.name),
+				['one'],
+				'the wildcard contributes nothing',
+			);
+			assert.deepEqual(wildcardMembers, ['crates/*']);
+		},
+	);
+});
+
+test('discoverOutOfTreeCrates: a member with no manifest is reported as unreadable', () => {
+	withProject(
+		{
+			'Cargo.toml': '[workspace]\nmembers = ["present", "gone"]\n',
+			'present/Cargo.toml': '[package]\nname = "present"\n',
+		},
+		(dir) => {
+			const { crates, unreadableMembers } = discoverOutOfTreeCrates(dir);
+			assert.deepEqual(
+				crates.map((c) => c.name),
+				['present'],
+			);
+			assert.deepEqual(unreadableMembers, ['gone']);
+		},
+	);
+});
+
+test('discoverOutOfTreeCrates: a workspace-only manifest does not borrow a name from another table', () => {
+	withProject(
+		{ 'Cargo.toml': '[workspace]\nmembers = []\n\n[workspace.package]\nname = "not_a_crate"\n' },
+		(dir) => {
+			const { crates } = discoverOutOfTreeCrates(dir);
+			assert.deepEqual(crates, []);
+		},
+	);
+});
+
+test('discoverOutOfTreeCrates: a folder with no Cargo.toml yields nothing and no complaints', () => {
+	withProject({ 'readme.txt': 'not a cargo project\n' }, (dir) => {
+		const result = discoverOutOfTreeCrates(dir);
+		assert.deepEqual(result, { crates: [], wildcardMembers: [], unreadableMembers: [] });
+	});
 });

--- a/src/util/appName.ts
+++ b/src/util/appName.ts
@@ -2,3 +2,8 @@
 export function isLikelyValidAppName(name: string): boolean {
 	return /^[a-z][a-z0-9_-]*$/.test(name);
 }
+
+/** Split the space-separated app/crate setting into names, ignoring stray whitespace. */
+export function splitAppNames(value: string | undefined): string[] {
+	return (value ?? '').trim().split(/\s+/).filter(Boolean);
+}

--- a/src/util/cargo.ts
+++ b/src/util/cargo.ts
@@ -17,6 +17,21 @@ export function readCargoPackageName(root: string): string | null {
 	}
 }
 
+/** Strip line comments so a table header inside a comment is not mistaken for a real one. */
+function stripTomlComments(toml: string): string {
+	return toml.replace(/#[^\n]*/g, '');
+}
+
+/** Whether a Cargo.toml declares a `[workspace]` table. */
+export function hasWorkspaceTable(toml: string): boolean {
+	return /^[ \t]*\[workspace\][ \t]*$/m.test(stripTomlComments(toml));
+}
+
+/** Whether a Cargo.toml declares a `[package]` table (absent in a workspace with no root crate). */
+export function hasPackageTable(toml: string): boolean {
+	return /^[ \t]*\[package\][ \t]*$/m.test(stripTomlComments(toml));
+}
+
 /** Extract the workspace member paths from a Cargo.toml's `members = [...]` array. */
 export function parseWorkspaceMembers(toml: string): string[] {
 	// Drop line comments first so a commented-out "member" (or a `]` inside a comment) neither
@@ -25,6 +40,66 @@ export function parseWorkspaceMembers(toml: string): string[] {
 	const m = withoutComments.match(/^members\s*=\s*\[([\s\S]*?)\]/m);
 	if (!m) return [];
 	return [...m[1].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+}
+
+/** A crate an out-of-tree project can build: its cargo package name and the manifest that declares it. */
+export type OutOfTreeCrate = {
+	/** Package name - what `cargo build -p` takes, and the filename of the built ELF. */
+	name: string;
+	/** Absolute path to this crate's Cargo.toml (the rev sync rewrites this file). */
+	manifestPath: string;
+};
+
+/**
+ * List the crates an out-of-tree project can build: the one `[package]`, or every `[workspace]`
+ * member plus the root crate when there is one. Members written with a `*`, and members whose
+ * manifest is missing, are reported separately rather than dropped.
+ */
+export function discoverOutOfTreeCrates(root: string): {
+	crates: OutOfTreeCrate[];
+	wildcardMembers: string[];
+	unreadableMembers: string[];
+} {
+	const rootManifest = path.join(root, 'Cargo.toml');
+	const crates: OutOfTreeCrate[] = [];
+	const wildcardMembers: string[] = [];
+	const unreadableMembers: string[] = [];
+
+	let content: string;
+	try {
+		content = fs.readFileSync(rootManifest, 'utf8');
+	} catch {
+		return { crates, wildcardMembers, unreadableMembers }; // not a cargo project
+	}
+
+	// Gated on [package]: a workspace-only manifest can carry a `name` under another table.
+	if (hasPackageTable(content)) {
+		const name = parseCargoPackageName(content);
+		if (name) crates.push({ name, manifestPath: rootManifest });
+	}
+
+	if (hasWorkspaceTable(content)) {
+		for (const member of parseWorkspaceMembers(content)) {
+			if (member.includes('*')) {
+				wildcardMembers.push(member);
+				continue;
+			}
+			const memberDir = path.join(root, member);
+			const name = readCargoPackageName(memberDir);
+			if (name) crates.push({ name, manifestPath: path.join(memberDir, 'Cargo.toml') });
+			else unreadableMembers.push(member);
+		}
+	}
+
+	// A root crate listed in its own `members` would otherwise appear twice.
+	const seen = new Set<string>();
+	const deduped = crates.filter((crate) => {
+		if (seen.has(crate.name)) return false;
+		seen.add(crate.name);
+		return true;
+	});
+
+	return { crates: deduped, wildcardMembers, unreadableMembers };
 }
 
 /**

--- a/src/views/tree/baoTree.ts
+++ b/src/views/tree/baoTree.ts
@@ -1,4 +1,5 @@
 import { Commands } from '@commands/commandIds';
+import { hasCrateChoice } from '@services/appService';
 import { getMonitorDefaultPort } from '@services/configService';
 import { getProjectMode } from '@services/projectModeService';
 import { buildCommandLabel, monitorTooltip } from '@views/uiLabels';
@@ -74,8 +75,16 @@ export class BaoTreeProvider implements vscode.TreeDataProvider<vscode.TreeItem>
 		if (element === this.projectSection) {
 			return Promise.resolve([
 				new TreeItem(vscode.l10n.t('New app'), Commands.createApp, 'add'),
-				...(getProjectMode() === 'xous-core'
-					? [new TreeItem(vscode.l10n.t('Select app'), Commands.selectApp, 'search')]
+				...(hasCrateChoice()
+					? [
+							new TreeItem(
+								getProjectMode() === 'xous-core'
+									? vscode.l10n.t('Select app')
+									: vscode.l10n.t('Select crate'),
+								Commands.selectApp,
+								'search',
+							),
+						]
 					: []),
 			]);
 		}


### PR DESCRIPTION
Now you can build several crates from one out-of-tree project into a single apps.uf2, and select several apps at once for in-tree builds.

- out-of-tree projects can be a cargo workspace; pick which members to build
- app picker is now multi-select in both modes, and pre-selects what is already set
- single-crate project fills the setting in automatically
- warns when the setting names crates the project does not have
- revision sync runs per selected crate plus the workspace root, and skips crates with no xous-core dependency
- status bar and sidebar show the crate selector only when there is something to choose
